### PR TITLE
Introduce EncryptedBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# PR [#2](https://github.com/theplant/appkit/pull/2)
+
+* Add `encryptedbox` package
+
 # PR [#43](https://github.com/theplant/appkit/pull/43)
 
 * Add `APPKIT_LOG_HUMAN` environment flag to output logs with better formatted for human

--- a/README.md
+++ b/README.md
@@ -113,3 +113,9 @@ For an "ABC" context:
 * `WithABC` is `http.Handler` middleware that will enable "ABC" in a HTTP handler.
 * `ABCContext` will wrap a `context.Context` and provide a new context that can be passed to `ABC`.
 * `MustGetABC` is a wrapper around `ABC` that will `panic` when `ABC` would return false. Useful when you *need* the context value and the only way you'd handle a missing value would be to `panic`.
+
+# [Encrypted Box](encryptedbox/README.md)
+
+Secret Box provides a simple interface for encryption of data for storage at rest.
+
+It is implemented as a simple wrapper around `golang.org/x/crypto/nacl/secretbox` that takes care of handling the nonce.

--- a/encryptedbox/README.md
+++ b/encryptedbox/README.md
@@ -1,0 +1,52 @@
+# Encrypted Box
+
+## Secret Box
+
+Secret Box provides a simple interface for encryption of data for storage at rest.
+
+It is implemented as a simple wrapper around `golang.org/x/crypto/nacl/secretbox` that takes care of handling the nonce by:
+
+1. Generating a random nonce for each message (192 bit nonce means
+   vanishingly small probability of nonce reuse).
+
+2. Encrypting the message with `secretBox.Seal`.
+
+3. Prefixing the nonce onto the encrypted result.
+
+As a wrapper of `secretbox`, the same caveats apply:
+
+> The length of messages is not hidden.
+
+The key must be 32 bytes long (as a requirement from `secretbox`).
+
+Usage:
+
+```
+box, err := NewSecretBox(key)
+
+if err != nil {
+	panic(err)
+}
+
+var message string
+
+// Seal/Encrypt
+cipher, err := box.SealString(message)
+if err != nil {
+	panic(err)
+}
+
+// Do something with cipher...
+
+// Open/Decrypt
+plaintext, err := box.Open(cipher)
+if err != nil {
+	panic(err)
+}
+
+// Do something with plaintext...
+```
+
+## Box
+
+Not implemented yet, but would be good to provide a simplified wrapper around `golang.org/x/crypto/nacl/box`.

--- a/encryptedbox/secretbox.go
+++ b/encryptedbox/secretbox.go
@@ -1,0 +1,101 @@
+package encryptedbox
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"golang.org/x/crypto/nacl/secretbox"
+)
+
+// length of secretbox's key and nonce as defined by secretbox's signature
+const keyLength = 32
+const nonceLength = 24
+
+// SecretBox presents simple interface for golang.org/x/crypto/nacl/secretbox
+type SecretBox interface {
+
+	// SealString will encrypt string, returning hex-encoded version
+	// of result
+	SealString(message string) (string, error)
+
+	Seal(message []byte) ([]byte, error)
+
+	// OpenString will decrypt hex-encoded string, returning
+	// hexencoded version of result
+	OpenString(hexmessage string) (string, error)
+
+	Open(message []byte) ([]byte, error)
+}
+
+// private implementation of SecretBox
+type secretBox struct {
+	key [keyLength]byte
+}
+
+// NewSecretBox creates SecretBox with key
+func NewSecretBox(key string) (SecretBox, error) {
+	box := &secretBox{}
+	if len(key) != keyLength {
+		return nil, fmt.Errorf("incorrect key length (expected %d bytes, got %d)", keyLength, len(key))
+	}
+
+	copy(box.key[:], key)
+
+	return box, nil
+}
+
+func (b *secretBox) SealString(message string) (string, error) {
+	cipher, error := b.Seal([]byte(message))
+	if error != nil {
+		return "", error
+	}
+	return hex.EncodeToString(cipher), nil
+}
+
+func (b *secretBox) Seal(message []byte) ([]byte, error) {
+	n, err := nonce()
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return secretbox.Seal((*n)[:], message, n, &b.key), nil
+}
+
+func (b *secretBox) OpenString(hexmessage string) (string, error) {
+	message, err := hex.DecodeString(hexmessage)
+	if err != nil {
+		return "", err
+	}
+
+	cipher, err := b.Open(message)
+	if err != nil {
+		return "", err
+	}
+	return string(cipher), nil
+}
+
+func (b *secretBox) Open(message []byte) ([]byte, error) {
+	var nonce [nonceLength]byte
+	copy(nonce[:], message[:nonceLength])
+	box := message[nonceLength:]
+
+	out := []byte{}
+
+	res, ok := secretbox.Open(out, box, &nonce, &b.key)
+
+	if !ok {
+		return []byte{}, errors.New("failed to open secret box")
+	}
+
+	return res, nil
+}
+
+func nonce() (*[nonceLength]byte, error) {
+	var n [nonceLength]byte
+
+	_, err := rand.Read(n[:])
+
+	return &n, err
+}

--- a/encryptedbox/secretbox_test.go
+++ b/encryptedbox/secretbox_test.go
@@ -1,0 +1,102 @@
+package encryptedbox
+
+import (
+	"fmt"
+	"testing"
+)
+
+const key = "12345678901234567890123456789012" // 32 bytes
+var box SecretBox
+
+func init() {
+	b, err := NewSecretBox(key)
+
+	if err != nil {
+		panic(err)
+	}
+
+	box = b
+}
+
+func TestInvalidSecretBoxKey(t *testing.T) {
+
+	cases := []string{
+		"",
+		"1234567890123456789012345678901",   // 31 bytes
+		"123456789012345678901234567890123", // 33 bytes
+	}
+
+	for _, key := range cases {
+		box, err := NewSecretBox(key)
+
+		if err == nil {
+			t.Fatalf("no error creating box with %d byte key", len(key))
+		}
+
+		if box != nil {
+			t.Fatalf("returned box with %d byte key", len(key))
+		}
+	}
+}
+
+func ExampleSecretBox_Bytes() {
+	message := "hello world"
+
+	fmt.Println(message)
+
+	cipher, err := box.Seal([]byte(message))
+	if err != nil {
+		panic(err)
+	}
+
+	plaintext, err := box.Open(cipher)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(plaintext))
+
+	// Output:
+	// hello world
+	// hello world
+}
+
+func ExampleSecretBox_String() {
+	message := "hello world"
+
+	fmt.Println(message)
+
+	cipher, err := box.SealString(message)
+
+	if err != nil {
+		panic(err)
+	}
+
+	plaintext, err := box.OpenString(cipher)
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(plaintext)
+
+	// Output:
+	// hello world
+	// hello world
+}
+
+func ExampleSecretBox_OpenString() {
+	// "hello world" sealed with key
+	message := "8cd92c57758b88a9208e30943b762b2f38f1719bbc75699b90578af008787cafcf72cdce1deef57880522bb84c6bec34e8cc6d"
+
+	plaintext, err := box.OpenString(message)
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(plaintext)
+
+	// Output:
+	// hello world
+}


### PR DESCRIPTION
Secret Box provides a simple interface for encryption of data for storage at rest.

It is implemented as a simple wrapper around `golang.org/x/crypto/nacl/secretbox` that takes care of handling the nonce by:

1. Generating a random nonce for each message (192 bit nonce means vanishingly small probability of nonce reuse).

2. Encrypting the message with `secretBox.Seal`.

3. Prefixing the nonce onto the encrypted result.