### PR TITLE
Workaround golang autogenerated:1 bug for log caller

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -75,7 +75,7 @@ func Default() Logger {
 	lg := Logger{
 		Logger: l,
 	}
-	lg = lg.With("ts", timer, "caller", log.DefaultCaller)
+	lg = lg.With("ts", timer, "caller", log.Caller(4))
 
 	return lg
 }


### PR DESCRIPTION
This is a Golang bug: https://github.com/golang/go/issues/16723

---

Log code

```go
	var logger = log.Default()
	logger.Error().Log("msg", "1234")
```

Now output

```
level=error ts=2017-09-04T16:57:23.219800913+08:00 caller=<autogenerated>:1 msg=1234
```

After fixed

```
level=error ts=2017-09-04T16:57:53.578378968+08:00 caller=log_test.go:88 msg=1234
```