### PR TITLE
log wait_us and serve_us in ListenAndServe

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	golog "log"
 	"net/http"
+	"time"
 
 	"github.com/theplant/appkit/log"
 )
@@ -30,11 +31,19 @@ func ListenAndServe(config Config, logger log.Logger, handler http.Handler) {
 	logger.Info().Log(
 		"addr", config.Addr,
 		"msg", fmt.Sprintf("HTTP server listening on %s", config.Addr),
+		"wait_us", sinceStart(),
 	)
 	if err := s.ListenAndServe(); err != nil {
 		logger.Error().Log(
 			"msg", fmt.Sprintf("Error in ListenAndServe: %v", err),
+			"serve_us", sinceStart(),
 			"err", err,
 		)
 	}
+}
+
+var start = time.Now()
+
+func sinceStart() int64 {
+	return int64(time.Now().Sub(start) / time.Microsecond)
 }


### PR DESCRIPTION
https://github.com/theplant/appkit/issues/26#issuecomment-453448539

Limitations:
1. wait_us not contains `init` functions exec time.
2. serve_us not able records log when a signal interrupt application.