### PR TITLE
Allow closing of server processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# PR [#30](https://github.com/theplant/appkit/pull/30)
+
+## Breaking Changes
+
+* `monitoring.NewInfluxdbMonitor` now returns a "close" `func()` to
+  allow termination of InfluxDB buffer introduced in #25.
+
+## Added
+
+* `server.GoListenAndServe` gives control over shut-down of the HTTP
+  server.
+
+
+## Changed Behaviour
+
+* `server.ListenAndServe` now delegates the HTTP server to this
+  function and `server.GoListenAndServe` and *manually* blocks forever
+  by deadlocking itself. This preserves the basic behaviour, but it
+  might change how `ListenAndServe` responded to OS signals.
+
+* Tracing on monitoring middleware was removed. Tracing now occurs on
+  the InfluxDB monitor buffer goroutine that sends batches of points
+  to InfluxDB.
+
 # PR [#25](https://github.com/theplant/appkit/pull/25)
 
 * Add batch write (buffer) for monitoring/influxdb.

--- a/monitoring/influxdb.go
+++ b/monitoring/influxdb.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	influxdb "github.com/influxdata/influxdb1-client/v2"
@@ -137,14 +138,21 @@ func parseInfluxMonitorConfig(config InfluxMonitorConfig) (*influxMonitorCfg, er
 // max-buffer-size is optional, default is 10000, it must > buffer-size,
 //   if the batch write fails and buffered size reach max-buffer-size then clean up the buffer (mean the data is lost).
 //
-// Will returns a error if monitorURL is invalid or not absolute.
+// The second return value is a function that will cause the batching
+// goroutine to write buffered points, then terminate. This function
+// will block until one attempt to flush the buffer completes (either
+// success or failure).
 //
-// Will not return error if InfluxDB is unavailable, but the returned
-// Monitor will log errors if it cannot push metrics into InfluxDB
-func NewInfluxdbMonitor(config InfluxMonitorConfig, logger log.Logger) (Monitor, error) {
+// The third return value will be non-nil if monitorURL is invalid or
+// not absolute.
+//
+// This function will not return error if InfluxDB is unavailable, but
+// the returned Monitor will log errors if it cannot push metrics into
+// InfluxDB.
+func NewInfluxdbMonitor(config InfluxMonitorConfig, logger log.Logger) (Monitor, func(), error) {
 	cfg, err := parseInfluxMonitorConfig(config)
 	if err != nil {
-		return nil, err
+		return nil, func() {}, err
 	}
 
 	httpConfig := influxdb.HTTPConfig{
@@ -156,8 +164,10 @@ func NewInfluxdbMonitor(config InfluxMonitorConfig, logger log.Logger) (Monitor,
 	client, err := influxdb.NewHTTPClient(httpConfig)
 
 	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't initialize influxdb http client with http config %+v", httpConfig)
+		return nil, func() {}, errors.Wrapf(err, "couldn't initialize influxdb http client with http config %+v", httpConfig)
 	}
+
+	logger = logger.With("context", "appkit/monitoring.influxdb")
 
 	monitor := &influxdbMonitor{
 		database: cfg.Database,
@@ -168,16 +178,17 @@ func NewInfluxdbMonitor(config InfluxMonitorConfig, logger log.Logger) (Monitor,
 		batchWriteInterval: cfg.BatchWriteInterval,
 		bufferSize:         cfg.BufferSize,
 		maxBufferSize:      cfg.MaxBufferSize,
+
+		done: &sync.WaitGroup{},
 	}
+
+	running := make(chan struct{})
 
 	logger = logger.With(
 		"scheme", cfg.Scheme,
 		"username", cfg.Username,
 		"database", monitor.database,
 		"host", cfg.Host,
-		"batch-write-interval", cfg.BatchWriteInterval.String(),
-		"buffer-size", cfg.BufferSize,
-		"max-buffer-size", cfg.MaxBufferSize,
 	)
 
 	// check connectivity to InfluxDB every 5 minutes
@@ -194,18 +205,36 @@ func NewInfluxdbMonitor(config InfluxMonitorConfig, logger log.Logger) (Monitor,
 					"msg", fmt.Sprintf("couldn't ping influxdb: %v", err),
 				)
 			}
+			select {
+			case <-t.C:
+				// continue
+			case <-running:
+				_ = logger.Info().Log(
+					"during", "influxdb.Client.Ping",
+					"msg", "influxdb monitor closed, stopping influxdb pings",
+				)
+				return
+			}
 
-			<-t.C
 		}
 	}()
 
-	go monitor.batchWriteDaemon()
+	go monitor.batchWriteDaemon(running)
 
 	_ = logger.Info().Log(
 		"msg", fmt.Sprintf("influxdb instrumentation writing to %s://%s@%s/%s", cfg.Scheme, cfg.Username, cfg.Host, monitor.database),
+		"batch-write-interval", cfg.BatchWriteInterval.String(),
+		"buffer-size", cfg.BufferSize,
+		"max-buffer-size", cfg.MaxBufferSize,
 	)
 
-	return monitor, nil
+	return monitor, func() {
+		_ = logger.Debug().Log(
+			"msg", "closing influxdb monitor",
+		)
+		close(running)
+		monitor.done.Wait()
+	}, nil
 }
 
 // InfluxdbMonitor implements monitor.Monitor interface, it wraps
@@ -219,13 +248,24 @@ type influxdbMonitor struct {
 	batchWriteInterval time.Duration
 	bufferSize         int
 	maxBufferSize      int
+
+	// We need a pointer here since:
+	//
+	// > A WaitGroup must not be copied after first use.
+	//
+	// https://godoc.org/sync#WaitGroup
+	done *sync.WaitGroup
 }
 
-func (im influxdbMonitor) batchWriteDaemon() {
+func (im influxdbMonitor) batchWriteDaemon(running chan struct{}) {
+	im.done.Add(1)
 	defer func() {
+		im.done.Done()
+
 		if r := recover(); r != nil {
 			_ = im.logger.Crit().Log(
-				"msg", "batchWriteDaemon panic",
+				"during", "influxdb.influxdbMonitor.batchWriteDaemon",
+				"msg", fmt.Sprintf("panic: %v", r),
 				"recover", r,
 			)
 		}
@@ -248,8 +288,18 @@ func (im influxdbMonitor) batchWriteDaemon() {
 			if len(points) >= nextWriteBufferSize {
 				im.batchWriteAndHandleErr(&points, &nextWriteBufferSize)
 			}
+
+		case <-running:
+			_ = im.logger.Debug().Log(
+				"msg", "influxdb monitor buffer closed, flushing buffer",
+				"point_count", len(points),
+			)
+			im.batchWriteAndHandleErr(&points, &nextWriteBufferSize)
+
+			return
 		}
 	}
+
 }
 
 func increaseBufferSize(nextWriteBufferSize, bufferSize, maxBufferSize int) int {

--- a/monitoring/middleware.go
+++ b/monitoring/middleware.go
@@ -8,12 +8,9 @@ import (
 	"strconv"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 	"github.com/theplant/appkit/contexts"
 	"github.com/theplant/appkit/contexts/trace"
 	"github.com/theplant/appkit/log"
-	"github.com/theplant/appkit/tracing"
 )
 
 type key int
@@ -31,15 +28,9 @@ func WithMonitor(m Monitor) func(h http.Handler) http.Handler {
 			defer func() {
 				interval := time.Now().Sub(start)
 				go func() {
-					tracing.Span(r.Context(), "appkit/monitoring.WithMonitor", func(ctx context.Context, span opentracing.Span) error {
-						ext.SpanKind.Set(span, ext.SpanKindRPCClientEnum)
-
-						tags := tagsForRequest(r)
-						fields := fieldsForContext(r.Context())
-						m.InsertRecord("request", float64(interval/time.Millisecond), tags, fields, start)
-						return nil
-					})
-
+					tags := tagsForRequest(r)
+					fields := fieldsForContext(r.Context())
+					m.InsertRecord("request", float64(interval/time.Millisecond), tags, fields, start)
 				}()
 			}()
 

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,7 @@ func newServer(config Config, logger log.Logger, handler http.Handler) *http.Ser
 }
 
 // ListenAndServe will start a HTTP server on config.Addr, using
-// handler to handle requests. This fuction will never return.
+// handler to handle requests. This function will never return.
 func ListenAndServe(config Config, logger log.Logger, handler http.Handler) {
 	GoListenAndServe(config, logger, handler)
 	// Ignore io.Closer, listen forever

--- a/server/server.go
+++ b/server/server.go
@@ -3,7 +3,9 @@
 package server
 
 import (
+	"context"
 	"fmt"
+	"io"
 	golog "log"
 	"net/http"
 	"time"
@@ -15,31 +17,67 @@ type Config struct {
 	Addr string `default:":9800"`
 }
 
-func newServer(config Config, logger log.Logger) *http.Server {
+func newServer(config Config, logger log.Logger, handler http.Handler) *http.Server {
 	server := http.Server{
 		Addr:     config.Addr,
 		ErrorLog: golog.New(log.LogWriter(logger.Error()), "", golog.Llongfile),
+		Handler:  handler,
 	}
+
 	return &server
 }
 
+// ListenAndServe will start a HTTP server on config.Addr, using
+// handler to handle requests. This fuction will never return.
 func ListenAndServe(config Config, logger log.Logger, handler http.Handler) {
-	logger = logger.With("during", "server.ListenAndServe")
-	s := newServer(config, logger)
-	s.Handler = handler
+	GoListenAndServe(config, logger, handler)
+	// Ignore io.Closer, listen forever
+	var ch chan struct{}
+	<-ch
+}
 
-	logger.Info().Log(
-		"addr", config.Addr,
-		"msg", fmt.Sprintf("HTTP server listening on %s", config.Addr),
-		"wait_us", sinceStart(),
-	)
-	if err := s.ListenAndServe(); err != nil {
-		logger.Error().Log(
-			"msg", fmt.Sprintf("Error in ListenAndServe: %v", err),
-			"serve_us", sinceStart(),
-			"err", err,
+type serverCloser func() error
+
+func (s serverCloser) Close() error {
+	return s()
+}
+
+// GoListenAndServe will start a HTTP server, on a separate goroutine,
+// on config.Addr, using handler to handle requests.
+//
+// Returns an io.Closer that can be used to terminate the HTTP
+// server. The closer will block with the same semantics as
+// net/http.Server.Shutdown
+// (https://godoc.org/net/http#Server.Shutdown)
+func GoListenAndServe(config Config, logger log.Logger, handler http.Handler) io.Closer {
+	logger = logger.With("during", "server.ListenAndServe")
+	s := newServer(config, logger, handler)
+
+	go func() {
+		logger.Info().Log(
+			"addr", config.Addr,
+			"msg", fmt.Sprintf("HTTP server listening on %s", config.Addr),
+			"wait_us", sinceStart(),
 		)
-	}
+
+		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error().Log(
+				"msg", fmt.Sprintf("error in ListenAndServe: %v", err),
+				"serve_us", sinceStart(),
+				"err", err,
+			)
+		}
+	}()
+
+	return serverCloser(func() error {
+		logger.Info().Log(
+			"msg", fmt.Sprintf("shutting down HTTP server on %v", config.Addr),
+			"addr", config.Addr,
+			"serve_us", sinceStart(),
+		)
+		return s.Shutdown(context.Background())
+	})
+
 }
 
 var start = time.Now()


### PR DESCRIPTION
- [x] HTTP server
- [x] InfluxDB
- [x] Trace InfluxDB requests, not HTTP requests

Jaeger's client already exposes a `func()` to allow flushing the tracing buffer.

Client apps will need to be restructured to listen for a signal, then shut down HTTP server, then shut-down tracing and InfluxDB monitoring.