### PR TITLE
Tracing improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# PR [#31](https://github.com/theplant/appkit/pull/31)
+
+* Log request id in trace log.
+* Log trace id in InfluxDB.
+* Add `service-name` config for InfluxDB.
+
 # PR [#30](https://github.com/theplant/appkit/pull/30)
 
 ## Breaking Changes

--- a/monitoring/middleware.go
+++ b/monitoring/middleware.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/theplant/appkit/contexts"
 	"github.com/theplant/appkit/contexts/trace"
 	"github.com/theplant/appkit/log"
@@ -89,6 +90,9 @@ func fieldsForContext(ctx context.Context) map[string]interface{} {
 
 	if reqID, ok := trace.RequestTrace(ctx); ok {
 		fields["req_id"] = fmt.Sprintf("%v", reqID)
+	}
+	if span := opentracing.SpanFromContext(ctx); span != nil {
+		fields["span_context"] = fmt.Sprintf("%v", span.Context())
 	}
 
 	return fields

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -9,6 +9,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/theplant/appkit/contexts"
+	ctxtrace "github.com/theplant/appkit/contexts/trace"
 	"github.com/theplant/appkit/log"
 	"github.com/theplant/appkit/server"
 	jaegercfg "github.com/uber/jaeger-client-go/config"
@@ -54,6 +55,9 @@ func trace(h http.Handler) http.Handler {
 			ext.SpanKind.Set(span, ext.SpanKindRPCServerEnum)
 			ext.HTTPMethod.Set(span, r.Method)
 			ext.HTTPUrl.Set(span, r.URL.String())
+			if ctxtraceID, ok := ctxtrace.RequestTrace(ctx); ok {
+				span.LogKV("req_id", ctxtraceID)
+			}
 
 			h.ServeHTTP(w, r.WithContext(ctx))
 			s, _ := contexts.HTTPStatus(ctx)


### PR DESCRIPTION
- [x] log request id in trace log
- [x] log trace id in InfluxDB
- [x] Include `service` as tag in InfluxDB logs (front-end uses `frontend-ssr` as service tag value)
- [ ] ~log request id in Airbrake on error~ move to new PR (big change)
- [ ] ~log trace id in Airbrake on error~ move to new PR (big change)