### PR TITLE
Introduce service package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# PR [#37](https://github.com/theplant/appkit/pull/37)
+
+* Add package appkit/service
+
 # PR [#19](https://github.com/theplant/appkit/pull/19)
 
 * Add Package appkit/credentials

--- a/README.md
+++ b/README.md
@@ -138,3 +138,9 @@ back-end.
 
 Package to provide single interface for acquiring AWS (-only, for now)
 credentials for apps running on different platforms.
+
+# [Service](service/README.md)
+
+Package to provide a common harness for running HTTP apps, that
+configures middleware that we use nearly all the time, and provides a
+standard way to configure the different parts of the service.

--- a/credentials/aws/aws.go
+++ b/credentials/aws/aws.go
@@ -88,7 +88,7 @@ func NewSession(logger log.Logger, vault *api.Client, path string) (*session.Ses
 
 	if vault != nil {
 		logger.Info().Log(
-			"msg", "initialising aws session with vault",
+			"msg", "using vault-backed aws session",
 		)
 
 		config := aws.NewConfig().WithCredentials(

--- a/credentials/aws/context.go
+++ b/credentials/aws/context.go
@@ -1,0 +1,21 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+type key int
+
+const (
+	awsKey key = iota
+)
+
+func ForceContext(ctx context.Context) *session.Session {
+	return ctx.Value(awsKey).(*session.Session)
+}
+
+func Context(ctx context.Context, s *session.Session) context.Context {
+	return context.WithValue(ctx, awsKey, s)
+}

--- a/credentials/vault/vault.go
+++ b/credentials/vault/vault.go
@@ -36,11 +36,6 @@ func NewVaultClient(logger log.Logger, config Config) (*api.Client, error) {
 		"role", config.Role,
 	)
 
-	logger.Debug().Log(
-		"msg", "creating vault client",
-		"token_filename", config.TokenFilename,
-	)
-
 	cfg := api.Config{
 		Address: config.Address,
 	}
@@ -50,11 +45,20 @@ func NewVaultClient(logger log.Logger, config Config) (*api.Client, error) {
 		tokBytes, err := ioutil.ReadFile(config.TokenFilename)
 
 		if os.IsNotExist(err) {
-			logger.Info().Log("msg", "no token and no token file, returning nil client")
+			logger.Info().Log("msg", "not creating vault client: no token and no token file")
 			return nil, nil
 		}
 
 		token = string(tokBytes)
+
+		logger.Info().Log(
+			"msg", fmt.Sprintf("creating vault client with token from %s", config.TokenFilename),
+			"token_filename", config.TokenFilename,
+		)
+	} else {
+		logger.Info().Log(
+			"msg", "creating vault client with token from environment",
+		)
 	}
 
 	client, err := api.NewClient(&cfg)

--- a/errornotifier/middleware.go
+++ b/errornotifier/middleware.go
@@ -20,7 +20,7 @@ const ctxKey key = iota
 func Recover(n Notifier) func(h http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			c := context.WithValue(req.Context(), ctxKey, n)
+			c := Context(req.Context(), n)
 			err := NotifyOnPanic(n, req, func() {
 				h.ServeHTTP(w, req.WithContext(c))
 			})
@@ -42,6 +42,11 @@ func ForceContext(c context.Context) Notifier {
 	}
 
 	return NewLogNotifier(log.ForceContext(c))
+}
+
+// Context installs a given Error Notifier in the returned context
+func Context(c context.Context, n Notifier) context.Context {
+	return context.WithValue(c, ctxKey, n)
 }
 
 // NotifyOnPanic will notify Airbrake if function f panics, and will

--- a/service/README.md
+++ b/service/README.md
@@ -78,11 +78,11 @@ configuration of https://github.com/rs/cors
 
 Environment variables:
 
-* `API_RawAllowedOrigins`: comma-separated list of allowed values for
+* `CORS_RawAllowedOrigins`: comma-separated list of allowed values for
   [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Access-Control-Allow-Origin)
   HTTP header.
 
-* `API_AllowCredentials`: boolean-ish value for
+* `CORS_AllowCredentials`: boolean-ish value for
   [`Access-Control-Allow-Credentials`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Access-Control-Allow-Credentials)
   HTTP header.
 

--- a/service/README.md
+++ b/service/README.md
@@ -64,11 +64,11 @@ In request-processing order:
 
 Environment variables:
 
-* `BASICAUTH_USERNAME`
-* `BASICAUTH_PASSWORD`
-* `BASICAUTH_USERAGENTWHITELISTREGEXP`: Regexp matched against HTTP
+* `BASICAUTH_Username`
+* `BASICAUTH_Password`
+* `BASICAUTH_UserAgentWhitelistRegexp`: Regexp matched against HTTP
   User-Agent header to bypass HTTP Basic Authentication.
-* `BASICAUTH_PATHWHITELISTREGEXP`: Regexp matched against request path
+* `BASICAUTH_PathWhitelistRegexp`: Regexp matched against request path
   to bypass HTTP Basic Authentication.
 
 ## CORS

--- a/service/README.md
+++ b/service/README.md
@@ -1,7 +1,166 @@
-- [ ] server harness
+This package provides a common harness for running HTTP apps, that
+configures middleware that we use nearly all the time, and provides a
+standard way to configure the different parts of the service.
 
-- [ ] common middleware
+Basic usage is to call `service.ListenAndServe`, and pass a function
+that registers your HTTP handlers on the `*http.ServeMux` parameter
+passed to your function.
 
-- [ ] common config
+There are some pre-configured common things available in the background context
+passed to the function:
 
-- [ ] share service name across logger/tracing/monitoring/errors/...etc
+* [Logger](../log)
+
+* [Monitor](../monitoring)
+
+* [Error Notifier](../errornotifier)
+
+* [Vault Client](../credentials/vault)
+
+* [AWS Session](../credentials/aws)
+
+Most of these are also made available via middleware, and *should be
+accessed via the HTTP request context instead*.
+
+## Middleware
+
+In request-processing order:
+
+1. `appkit/server` default middleware:
+
+   1. HTTP status memoisation
+   2. Taggin request with UUID
+   3. Adding logger to request context
+   4. Logging request/response
+   5. `recover`ing from `panic`, and returning `500 Internal Server
+      Error` if no other HTTP status has been "sent" from a later
+      handler.
+
+2. Request tracing via Opentracing/Jaeger
+3. Notification of `panic`s to Airbrake
+4. Logging request metrics in InfluxDB
+5. Sending request information to New Relic
+6. CORS handling
+7. HTTP Basic Authentication
+8. Adding AWS session to request context
+
+# Configuration
+
+## General Configuration
+
+`SERVICE_NAME` can be set in the environment, this will be used by:
+
+* Loggger: as `svc` field.
+
+* Vault+AWS client credentials sourcing: as default role for Vault
+  authn, and default AWS credentials path.
+
+* Request Tracing (Opentracing/Jaeger): As service name for traced
+  requests.
+
+* New Relic Middleware: Application name reported to New Relic.
+
+## HTTP Basic Authentication
+
+Environment variables:
+
+* `BASICAUTH_USERNAME`
+* `BASICAUTH_PASSWORD`
+
+## CORS
+
+[CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+configuration of https://github.com/rs/cors
+
+Environment variables:
+
+* `API_RawAllowedOrigins`: comma-separated list of allowed values for
+  [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Access-Control-Allow-Origin)
+  HTTP header.
+
+* `API_AllowCredentials`: boolean-ish value for
+  [`Access-Control-Allow-Credentials`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Access-Control-Allow-Credentials)
+  HTTP header.
+
+## Vault/AWS Session
+    
+Environment variables:
+    
+* `VAULT_AUTHN_ADDRESS`: base URL of Vault server.
+
+* `VAULT_AUTH_PATH`: path to Vault K8s auth backend. By default this
+  is set to `auth/kubernetes/login`.
+
+* `VAULT_AUTH_ROLE`: role used when authenticating with Vault. By
+default this is set to `$SERVICE_NAME`.
+
+* `VAULT_AUTH_AUTORENEW`: flag to enable/disable automatic renewal of
+  Vault lease in background goroutine. Defaults to `true`.
+
+* `VAULT_AWSPATH`: When using AWS credentials sourced from Vault, the
+Vault path of the credentials secret. By default this is set to
+`aws/sts/<$SERVICE_NAME>`.
+
+## HTTP Server
+
+Server port/interface is configurable via [TBD oops, not configurable!]
+
+## Monitor
+
+`INFLUXDB_URL`: Set to URL of InfluxDB server. If blank, a logging
+(via `appkit/log` monitor will be used instead of sending data to
+InfluxDB.
+
+## Error Notifier
+
+* `AIRBRAKE_PROJECTID`
+* `AIRBRAKE_TOKEN`
+* `AIRBRAKE_ENV`
+
+If notifier can't be created due to blank project ID or token, a
+logging notifier will be used instead.
+
+## New Relic
+
+* `NEWRELICAPIKEY`
+* `NEWRELICAPPNAME`: If this is blank, `$SERVICE_NAME` will be used.
+
+## Tracer
+
+Configured as for [Jaeger Go
+client](https://github.com/jaegertracing/jaeger-client-go). 
+
+If `JAEGER_SERVICE_NAME` is blank, `$SERVICE_NAME` will be used.
+
+
+# Design Background
+
+Design is implemented via a configuration callback because the
+lifecycle of the app is controlled by the serivce harness.
+
+1. Create and configure service background context (including starting
+   background goroutines used by some middleware).
+
+2. Set up common middleware using background context.
+
+3. Hand over to app-side code (passed function) to do app-specific
+   configuration.
+
+4. App-side code hands back to the service harness (by returning from
+   the passed function).
+
+5. Start HTTP server in background goroutine.
+
+6. Wait for signal to terminate.
+
+7. Ask HTTP server to shut down, and wait.
+
+8. Once HTTP server has shut down (=> all requests have been handled
+   or rejected, no more HTTP requests will be accepted), shut down
+   background context goroutines.
+
+9. Exit
+
+The reason for this structure is that step 7 needs to finish *before*
+step 8 is started, and managing this lifecycle is somewhat complex,
+and tedious. So we don't want to implement it in *every* service.

--- a/service/README.md
+++ b/service/README.md
@@ -66,6 +66,10 @@ Environment variables:
 
 * `BASICAUTH_USERNAME`
 * `BASICAUTH_PASSWORD`
+* `BASICAUTH_USERAGENTWHITELISTREGEXP`: Regexp matched against HTTP
+  User-Agent header to bypass HTTP Basic Authentication.
+* `BASICAUTH_PATHWHITELISTREGEXP`: Regexp matched against request path
+  to bypass HTTP Basic Authentication.
 
 ## CORS
 

--- a/service/README.md
+++ b/service/README.md
@@ -128,8 +128,8 @@ logging notifier will be used instead.
 
 ## New Relic
 
-* `NEWRELICAPIKEY`
-* `NEWRELICAPPNAME`: If this is blank, `$SERVICE_NAME` will be used.
+* `NEWRELIC_APIKey`
+* `NEWRELIC_AppName`: If this is blank, `$SERVICE_NAME` will be used.
 
 ## Tracer
 

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,7 @@
+- [ ] server harness
+
+- [ ] common middleware
+
+- [ ] common config
+
+- [ ] share service name across logger/tracing/monitoring/errors/...etc

--- a/service/README.md
+++ b/service/README.md
@@ -103,7 +103,9 @@ Vault path of the credentials secret. By default this is set to
 
 ## HTTP Server
 
-Server port/interface is configurable via [TBD oops, not configurable!]
+`PORT`: port number for HTTP server to bind to, defaults to `9800`. If
+required, `ADDR` can be set instead to allow binding to a specific
+interface/IP address using `[interface]:port` syntax.
 
 ## Monitor
 

--- a/service/context.go
+++ b/service/context.go
@@ -75,7 +75,7 @@ func installMonitor(ctx context.Context, l log.Logger) (monitoring.Monitor, io.C
 
 err:
 	l.Warn().Log(
-		"msg", errors.Wrap(err, "error creating influxdb monitor"),
+		"msg", errors.Wrap(err, "falling back to log monitor: error creating influxdb monitor"),
 		"err", err,
 	)
 	return monitoring.NewLogMonitor(l), noopCloser, ctx
@@ -94,7 +94,7 @@ func installErrorNotifier(ctx context.Context, l log.Logger) (errornotifier.Noti
 	n, closer, err := errornotifier.NewAirbrakeNotifier(airbrakeConfig)
 	if err != nil {
 		l.Warn().Log(
-			"msg", errors.Wrap(err, "error creating airbrake notifier"),
+			"msg", errors.Wrap(err, "falling back to log error notifier: error creating airbrake notifier"),
 			"err", err,
 		)
 

--- a/service/context.go
+++ b/service/context.go
@@ -34,7 +34,7 @@ func serviceContext() (context.Context, io.Closer) {
 
 	ctx = installAWSSession(ctx, logger, cfg.AWSPath, vault)
 
-	return ctx, FuncCloser{mC, nC}
+	return ctx, funcCloser{mC, nC}
 }
 
 func installLogger(ctx context.Context, serviceName string) (log.Logger, context.Context) {
@@ -52,12 +52,12 @@ func installLogger(ctx context.Context, serviceName string) (log.Logger, context
 	return logger, log.Context(ctx, logger)
 }
 
-var noopCloser = NoopCloser(func() {})
+var noopCloser = noopCloserF(func() {})
 
 ////////////////////////////////////////////////////////////
 // Metric Monitor
 
-type InfluxDBConfig struct {
+type influxDBConfig struct {
 	URL string
 }
 
@@ -65,7 +65,7 @@ func installMonitor(ctx context.Context, l log.Logger) (monitoring.Monitor, io.C
 	var monitor monitoring.Monitor
 	var closer func()
 
-	config := InfluxDBConfig{}
+	config := influxDBConfig{}
 	err := configor.New(&configor.Config{ENVPrefix: "INFLUXDB"}).Load(&config)
 	if err != nil {
 		goto err
@@ -82,7 +82,7 @@ func installMonitor(ctx context.Context, l log.Logger) (monitoring.Monitor, io.C
 		goto err
 	}
 
-	return monitor, NoopCloser(closer), monitoring.Context(ctx, monitor)
+	return monitor, noopCloserF(closer), monitoring.Context(ctx, monitor)
 
 err:
 	l.Warn().Log(
@@ -128,7 +128,6 @@ type key int
 
 const (
 	vaultKey key = iota
-	awsKey
 )
 
 func credentialsConfig(serviceName string) credentials.Config {

--- a/service/context.go
+++ b/service/context.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/jinzhu/configor"
+	"github.com/pkg/errors"
+	"github.com/theplant/appkit/log"
+	"github.com/theplant/appkit/monitoring"
+)
+
+func serviceContext() (context.Context, io.Closer) {
+	ctx := context.Background()
+
+	logger, ctx := installLogger(ctx)
+
+	_, mC, ctx := installMonitor(ctx, logger)
+
+	return ctx, FuncCloser{mC}
+}
+
+func installLogger(ctx context.Context) (log.Logger, context.Context) {
+	logger := log.Default()
+
+	serviceName := os.Getenv("SERVICE_NAME")
+	if serviceName == "" {
+		logger.Warn().Log("msg", "creating service context, SERVICE_NAME not set")
+	} else {
+		logger = logger.With("svc", serviceName)
+		logger.Info().Log(
+			"msg", fmt.Sprintf("creating service context for %s", serviceName),
+		)
+	}
+
+	return logger, log.Context(ctx, logger)
+}
+
+var noopCloser = NoopCloser(func() {})
+
+type InfluxDBConfig struct {
+	URL string
+}
+
+func installMonitor(ctx context.Context, l log.Logger) (monitoring.Monitor, io.Closer, context.Context) {
+	var monitor monitoring.Monitor
+	var closer func()
+
+	config := InfluxDBConfig{}
+	err := configor.New(&configor.Config{ENVPrefix: "INFLUXDB"}).Load(&config)
+	if err != nil {
+		goto err
+	}
+
+	if config.URL == "" {
+		err = errors.New("blank influxdb url")
+		goto err
+	}
+
+	monitor, closer, err = monitoring.NewInfluxdbMonitor(monitoring.InfluxMonitorConfig(config.URL), l)
+	if err != nil {
+		closer()
+		goto err
+	}
+
+	return monitor, NoopCloser(closer), monitoring.Context(ctx, monitor)
+
+err:
+	l.Warn().Log(
+		"msg", errors.Wrap(err, "error creating influxdb monitor"),
+		"err", err,
+	)
+	return monitoring.NewLogMonitor(l), noopCloser, ctx
+}

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -1,0 +1,272 @@
+package service
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/jinzhu/configor"
+	newrelic "github.com/newrelic/go-agent"
+	"github.com/pkg/errors"
+	"github.com/rs/cors"
+	"github.com/theplant/appkit/errornotifier"
+	"github.com/theplant/appkit/log"
+	"github.com/theplant/appkit/monitoring"
+	"github.com/theplant/appkit/server"
+	"github.com/theplant/appkit/tracing"
+)
+
+type APIConfig struct {
+	// CORS, allowed front-end request
+	RawAllowedOrigins string `required:"true"`
+	AllowedOrigins    []string
+	AllowCredentials  bool
+
+	//HTTP Auth
+	HTTPAuthName     string
+	HTTPAuthPassword string
+}
+
+func middleware(logger log.Logger) (server.Middleware, io.Closer, error) {
+	apiCfg := MustGetAPIConfig()
+
+	c := cors.New(cors.Options{
+		AllowedOrigins:   apiCfg.AllowedOrigins,
+		AllowCredentials: apiCfg.AllowCredentials,
+	})
+	//c.Log = stdlog.New(os.Stdout, "", stdlog.Llongfile)
+	logger.Info().Log(
+		"msg", "init cors successfully",
+		"allowed_origins", strings.Join(apiCfg.AllowedOrigins, ","),
+		"allow_credentials", apiCfg.AllowCredentials,
+	)
+
+	tC, tracer, err := tracing.Tracer(logger)
+	if err != nil {
+		// FIXME returning nil io.Closer
+		return nil, nil, errors.Wrap(err, "error configuring tracer")
+	}
+
+	errorNotifier, eC := MustGetErrorNotifier(logger)
+	monitor, mC := MustGetMonitor(logger)
+	appconf := MustGetAppConfig()
+	return server.Compose(
+			c.Handler,
+			NewRelicMiddleWare(logger, appconf.NewRelicAppName, appconf.NewRelicAPIKey),
+			monitoring.WithMonitor(monitor),
+			errornotifier.Recover(errorNotifier),
+			tracer,
+			server.DefaultMiddleware(logger),
+		), FuncCloser{
+			NoopCloser(mC),
+			tC,
+			eC,
+		}, nil
+}
+
+func NewRelicMiddleWare(log log.Logger, NewRelicAppName string, NewRelicAPIKey string) func(http.Handler) http.Handler {
+	config := newrelic.NewConfig(NewRelicAppName, NewRelicAPIKey)
+	app, err := newrelic.NewApplication(config)
+	if err != nil {
+		log.Warn().Log(
+			"msg", "error creating new relic agent",
+			"err", err,
+		)
+		return func(handler http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handler.ServeHTTP(w, r)
+			})
+		}
+	}
+
+	if app == nil {
+		panic("Both of app and err are nil when new Application!")
+	}
+
+	return func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			txn := app.StartTransaction(r.URL.Path, w, r)
+			defer txn.End()
+			handler.ServeHTTP(w, r)
+		})
+	}
+}
+
+var (
+	_errorNotifier       errornotifier.Notifier
+	_errorNotifierCloser io.Closer
+)
+
+func MustGetErrorNotifier(l log.Logger) (errornotifier.Notifier, io.Closer) {
+	if _errorNotifier != nil {
+		return _errorNotifier, _errorNotifierCloser
+	}
+
+	airbrakeConfig := MustGetAirbrakeConfig()
+	n, closer, err := errornotifier.NewAirbrakeNotifier(airbrakeConfig)
+	if err != nil {
+		l.Warn().Log(
+			"msg", "error creating airbrake notifier",
+			"err", err,
+		)
+
+		_errorNotifier = errornotifier.NewLogNotifier(l)
+		_errorNotifierCloser = NoopCloser(func() {
+			_ = l.Info().Log(
+				"msg", "error notifier is closed",
+			)
+		})
+	} else {
+		l.Info().Log(
+			"msg", "creating airbrake notifier sucessful",
+			"project_id", airbrakeConfig.ProjectID,
+			"env", airbrakeConfig.Environment,
+		)
+		_errorNotifier = n
+		_errorNotifierCloser = closer
+	}
+
+	return _errorNotifier, _errorNotifierCloser
+}
+
+var _monitor monitoring.Monitor
+
+var _closer = func() {}
+
+func MustGetMonitor(l log.Logger) (monitoring.Monitor, func()) {
+	if _monitor != nil {
+		return _monitor, _closer
+	}
+
+	c := MustGetInfluxDBConfig()
+	if c.URL == "" {
+		_monitor = monitoring.NewLogMonitor(l)
+		l.Warn().Log(
+			"msg", "error creating influxdb monitor",
+			"err", "blank influxdb url",
+		)
+		return _monitor, _closer
+	}
+	if m, closer, err := monitoring.NewInfluxdbMonitor(monitoring.InfluxMonitorConfig(c.URL), l); err != nil {
+		l.Warn().Log(
+			"msg", "error creating influxdb monitor",
+			"err", err,
+		)
+		_monitor = monitoring.NewLogMonitor(l)
+	} else {
+		_monitor = m
+		_closer = closer
+	}
+
+	return _monitor, _closer
+}
+
+// AppConfig defines the app's required configuration
+type AppConfig struct {
+	NewRelicAPIKey  string
+	NewRelicAppName string
+}
+
+var _appConfig *AppConfig
+
+func MustGetAppConfig() *AppConfig {
+	if _appConfig != nil {
+		return _appConfig
+	}
+
+	_appConfig = &AppConfig{}
+	err := configor.New(nil).Load(_appConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	return _appConfig
+}
+
+var _airbrakeConfig *errornotifier.AirbrakeConfig
+
+func MustGetAirbrakeConfig() errornotifier.AirbrakeConfig {
+	if _airbrakeConfig != nil {
+		return *_airbrakeConfig
+	}
+
+	_airbrakeConfig = &errornotifier.AirbrakeConfig{}
+	err := configor.New(&configor.Config{ENVPrefix: "AIRBRAKE"}).Load(_airbrakeConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	return *_airbrakeConfig
+}
+
+type InfluxDBConfig struct {
+	URL string
+}
+
+var _influxDBConfig *InfluxDBConfig
+
+func MustGetInfluxDBConfig() InfluxDBConfig {
+	if _influxDBConfig != nil {
+		return *_influxDBConfig
+	}
+
+	config := InfluxDBConfig{}
+	err := configor.New(&configor.Config{ENVPrefix: "INFLUXDB"}).Load(&config)
+	if err != nil {
+		panic(err)
+	}
+
+	_influxDBConfig = &config
+	return config
+}
+
+// NoopCloser is an adapter from `func()` to io.Closer, that calls
+// given function and returns nil
+type NoopCloser func()
+
+// Close is part of io.Closer
+func (f NoopCloser) Close() error {
+	f()
+	return nil
+}
+
+// FuncCloser aggregates io.Closers into a single io.Closer that
+// collects errors from each io.Closer function in the array when
+// closed.
+type FuncCloser []io.Closer
+
+// Close is part of io.Closer
+func (f FuncCloser) Close() error {
+	var err error
+	for _, c := range f {
+		if e := c.Close(); e != nil {
+			err = multierror.Append(err, e)
+		}
+	}
+
+	return err
+}
+
+var _apiConfig *APIConfig
+
+func MustGetAPIConfig() APIConfig {
+	if _apiConfig != nil {
+		return *_apiConfig
+	}
+
+	apiConfig := APIConfig{}
+	err := configor.New(&configor.Config{ENVPrefix: "API"}).Load(&apiConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	apiConfig.AllowedOrigins = strings.Split(apiConfig.RawAllowedOrigins, ",")
+	for i, allowedOrigin := range apiConfig.AllowedOrigins {
+		apiConfig.AllowedOrigins[i] = strings.TrimSpace(allowedOrigin)
+	}
+
+	_apiConfig = &apiConfig
+
+	return apiConfig
+}

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -140,7 +140,7 @@ type corsConfig struct {
 func corsMiddleware(logger log.Logger) server.Middleware {
 	config := corsConfig{}
 
-	err := configor.New(&configor.Config{ENVPrefix: "API"}).Load(&config)
+	err := configor.New(&configor.Config{ENVPrefix: "CORS"}).Load(&config)
 	if err != nil {
 		panic(err)
 	}

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -143,7 +143,7 @@ func corsMiddleware(logger log.Logger) server.Middleware {
 
 	if config.RawAllowedOrigins == "" {
 		logger.Warn().Log(
-			"msg", "not enabling CORS middleware, CORS configuration is blank",
+			"msg", "not enabling CORS middleware: CORS configuration is blank",
 			"raw_allowed_origins", config.RawAllowedOrigins,
 			"allowed_credentials", config.AllowCredentials,
 		)
@@ -186,8 +186,8 @@ func httpAuthMiddleware(logger log.Logger) server.Middleware {
 	}
 
 	if config.Username == "" {
-		logger.Warn().Log(
-			"msg", "not enabling HTTP basic auth middleware, username is blank",
+		logger.Info().Log(
+			"msg", "not enabling HTTP basic auth middleware: username is blank",
 		)
 		return server.IdMiddleware
 	}

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -8,12 +8,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/goji/httpauth"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/jinzhu/configor"
 	newrelic "github.com/newrelic/go-agent"
 	"github.com/pkg/errors"
 	"github.com/rs/cors"
+	"github.com/theplant/appkit/credentials/aws"
 	"github.com/theplant/appkit/errornotifier"
 	"github.com/theplant/appkit/log"
 	"github.com/theplant/appkit/monitoring"
@@ -37,6 +39,7 @@ func middleware(ctx context.Context) (server.Middleware, io.Closer, error) {
 	}
 
 	return server.Compose(
+		withAWSSession(aws.ForceContext(ctx)),
 		httpAuthMiddleware(logger),
 		corsMiddleware(logger),
 		NewRelicMiddleWare(logger),
@@ -197,4 +200,15 @@ func httpAuthMiddleware(logger log.Logger) server.Middleware {
 		"username", config.Username,
 	)
 	return httpauth.SimpleBasicAuth(config.Username, config.Password)
+}
+
+////////////////////////////////////////////////////////////
+// AWS Session in request context
+
+func withAWSSession(s *session.Session) server.Middleware {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r.WithContext(aws.Context(r.Context(), s)))
+		})
+	}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/theplant/appkit/log"
+	"github.com/theplant/appkit/server"
+)
+
+func logErr(l log.Logger, f func() error) {
+	if err := f(); err != nil {
+		l.WithError(err).Log()
+	}
+}
+
+func ListenAndServe(app func(*http.ServeMux) error) {
+	logger := log.Default()
+
+	mux := http.NewServeMux()
+
+	if err := app(mux); err != nil {
+		err = errors.Wrap(err, "error configuring service")
+		logger.WithError(err).Log()
+		return
+	}
+
+	m, c, err := middleware(logger)
+	if err != nil {
+		err = errors.Wrap(err, "error configuring service middleware")
+		logger.WithError(err).Log()
+		return
+	}
+	defer c.Close()
+
+	hc := server.GoListenAndServe(
+		server.Config{
+			Addr: ":9800",
+		},
+		logger,
+		m(mux),
+	)
+	// defers are LIFO, so the HTTP server will be closed *before* the
+	// routes
+	defer logErr(logger, hc.Close)
+
+	ch := make(chan os.Signal)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+
+	sig := <-ch
+
+	logger.Info().Log(
+		"msg", fmt.Sprintf("received signal %v, exiting", sig),
+		"signal", sig,
+	)
+
+}

--- a/service/service.go
+++ b/service/service.go
@@ -60,7 +60,7 @@ func ListenAndServe(app func(context.Context, *http.ServeMux) error) {
 	// routes
 	defer logErr(logger, hc.Close)
 
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 
 	sig := <-ch

--- a/service/service.go
+++ b/service/service.go
@@ -21,14 +21,6 @@ func logErr(l log.Logger, f func() error) {
 func ListenAndServe(app func(*http.ServeMux) error) {
 	logger := log.Default()
 
-	mux := http.NewServeMux()
-
-	if err := app(mux); err != nil {
-		err = errors.Wrap(err, "error configuring service")
-		logger.WithError(err).Log()
-		return
-	}
-
 	m, c, err := middleware(logger)
 	if err != nil {
 		err = errors.Wrap(err, "error configuring service middleware")
@@ -36,6 +28,14 @@ func ListenAndServe(app func(*http.ServeMux) error) {
 		return
 	}
 	defer c.Close()
+
+	mux := http.NewServeMux()
+
+	if err := app(mux); err != nil {
+		err = errors.Wrap(err, "error configuring service")
+		logger.WithError(err).Log()
+		return
+	}
 
 	hc := server.GoListenAndServe(
 		server.Config{

--- a/service/service.go
+++ b/service/service.go
@@ -41,10 +41,18 @@ func ListenAndServe(app func(context.Context, *http.ServeMux) error) {
 		return
 	}
 
+	cfg := server.Config{}
+	cfg.Addr = os.Getenv("ADDR")
+	if cfg.Addr == "" {
+		port := os.Getenv("PORT")
+		if port == "" {
+			port = "9800"
+		}
+		cfg.Addr = ":" + port
+	}
+
 	hc := server.GoListenAndServe(
-		server.Config{
-			Addr: ":9800",
-		},
+		cfg,
 		logger,
 		m(mux),
 	)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,0 +1,180 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+// ADDR -> PORT -> 9800 fallback
+func TestServerPort(t *testing.T) {
+	port := "19999"
+
+	os.Setenv("PORT", port)
+	defer func() { os.Unsetenv("PORT") }()
+
+	testServer(t, port)
+}
+
+func TestServerAddr(t *testing.T) {
+	port := "20001"
+
+	os.Setenv("ADDR", ":"+port)
+	defer func() { os.Unsetenv("ADDR") }()
+
+	testServer(t, port)
+}
+
+func TestServerDefaultPort(t *testing.T) {
+	testServer(t, "9800")
+
+}
+
+func testServer(t *testing.T, port string) {
+
+	ch := make(chan struct{})
+
+	go ListenAndServe(func(_ context.Context, mux *http.ServeMux) error {
+		mux.HandleFunc("/", func(_ http.ResponseWriter, _ *http.Request) {
+			go func() { ch <- struct{}{} }()
+		})
+		return nil
+	})
+
+	<-time.After(100 * time.Millisecond)
+
+	_, err := http.Get("http://localhost:" + port)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-ch:
+
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for request")
+	}
+}
+
+func TestBasicAuth(t *testing.T) {
+	os.Setenv("BASICAUTH_USERNAME", "username")
+	defer func() { os.Unsetenv("BASICAUTH_USERNAME") }()
+
+	os.Setenv("BASICAUTH_PASSWORD", "password")
+	defer func() { os.Unsetenv("BASICAUTH_PASSWORD") }()
+
+	os.Setenv("BASICAUTH_USERAGENTWHITELISTREGEXP", "non-default-user-agent")
+	defer func() { os.Unsetenv("BASICAUTH_USERAGENTWHITELISTREGEXP") }()
+
+	os.Setenv("BASICAUTH_PATHWHITELISTREGEXP", "/whitelisted-path")
+	defer func() { os.Unsetenv("BASICAUTH_PATHWHITELISTREGEXP") }()
+
+	ctx, c := serviceContext()
+	defer c.Close()
+
+	m, c2, err := middleware(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+
+	h := m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(204)
+	}))
+
+	t.Run("http auth with username/password", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		r.SetBasicAuth("username", "password")
+
+		w := httptest.ResponseRecorder{}
+
+		h.ServeHTTP(&w, r)
+
+		if w.Code != 204 {
+			t.Fatalf("unexpected status code, wanted 204, got %d", w.Code)
+		}
+	})
+
+	cases := []struct {
+		userAgent string
+		path      string
+		expected  int
+	}{
+		{userAgent: "non-default-user-agent", path: "/", expected: 204},
+		{path: "/whitelisted-path", expected: 204},
+		{userAgent: "non-default-user-agent", path: "/whitelisted-path", expected: 204},
+		{path: "/", expected: 401},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("http auth with %+v", c), func(t *testing.T) {
+			r := httptest.NewRequest("GET", c.path, nil)
+			if c.userAgent != "" {
+				r.Header.Set("User-Agent", c.userAgent)
+			}
+
+			w := httptest.ResponseRecorder{}
+
+			h.ServeHTTP(&w, r)
+
+			if w.Code != c.expected {
+				t.Fatalf("unexpected status code, wanted %d, got %d", c.expected, w.Code)
+			}
+		})
+	}
+}
+
+func TestCORS(t *testing.T) {
+	// Loose testing of CORS configuration
+	os.Setenv("CORS_RawAllowedOrigins", "cors1.example.com,cors2.example.com")
+	defer func() { os.Unsetenv("CORS_RawAllowedOrigins") }()
+
+	os.Setenv("CORS_AllowCredentials", "true")
+	defer func() { os.Unsetenv("CORS_AllowCredentials") }()
+
+	ctx, c := serviceContext()
+	defer c.Close()
+
+	m, c2, err := middleware(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+
+	h := m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(204)
+	}))
+
+	cases := []struct {
+		origin   string
+		expected string
+	}{
+		{origin: "cors1.example.com", expected: "cors1.example.com"},
+		{origin: "cors2.example.com", expected: "cors2.example.com"},
+		{origin: "not-cors", expected: ""},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("request with %+v", c), func(t *testing.T) {
+			r := httptest.NewRequest("OPTIONS", "/", nil)
+			if c.origin != "" {
+				r.Header.Set("Origin", c.origin)
+			}
+			r.Header.Set("Access-Control-Request-Method", "GET")
+
+			w := httptest.ResponseRecorder{}
+
+			h.ServeHTTP(&w, r)
+
+			if w.Header().Get("Access-Control-Allow-Origin") != c.expected {
+				t.Fatalf("unexpected response, wanted %q, got %q", c.origin, w.Header().Get("Access-Control-Allow-Origin"))
+
+			}
+		})
+	}
+}


### PR DESCRIPTION
`service` is a "harness" that takes care of a lot of busywork when starting services:

* Configuring/starting/stopping HTTP server
* Configuring common middleware
* Providing access to common resources
* Managing lifecycle for background tasks that need to be notified to allow clean-up after HTTP server shuts down, but before process exits (Tracing/Error Notification/Monitoring)
* Standardise environment configuration for common resources
