### PR TITLE
Add support for `VAULT_AUTHN_DISABLED`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# PR [#38](https://github.com/theplant/appkit/pull/38)
+
+* Add support for `VAULT_AUTHN_DISABLED` to stop appkit/service
+  automatically attempting to authenticate with Vault.
+
 # PR [#37](https://github.com/theplant/appkit/pull/37)
 
 * Add package appkit/service

--- a/credentials/vault/vault.go
+++ b/credentials/vault/vault.go
@@ -26,6 +26,8 @@ type Config struct {
 
 	Token         string
 	TokenFilename string `default:"/var/run/secrets/kubernetes.io/serviceaccount/token"`
+
+	Disabled bool
 }
 
 func NewVaultClient(logger log.Logger, config Config) (*api.Client, error) {
@@ -35,6 +37,11 @@ func NewVaultClient(logger log.Logger, config Config) (*api.Client, error) {
 		"auth_path", config.AuthPath,
 		"role", config.Role,
 	)
+
+	if config.Disabled {
+		logger.Info().Log("msg", "not creating vault client: vault disabled by configuration")
+		return nil, nil
+	}
 
 	cfg := api.Config{
 		Address: config.Address,

--- a/service/README.md
+++ b/service/README.md
@@ -105,6 +105,10 @@ default this is set to `$SERVICE_NAME`.
 Vault path of the credentials secret. By default this is set to
 `aws/sts/<$SERVICE_NAME>`.
 
+* `VAULT_AUTHN_DISABLED`: flag to enable/disable Vault authentication
+  completely. Use this when the service does not need any access to
+  Vault.
+
 ## HTTP Server
 
 `PORT`: port number for HTTP server to bind to, defaults to `9800`. If


### PR DESCRIPTION
This is to stop appkit/service automatically attempting to authenticate with Vault, for services that are running on K8s but don't need any data from Vault.