### PR TITLE
Allow configure allow headers for CORS in appkit/service package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# PR [#43](https://github.com/theplant/appkit/pull/43)
+
+* Allow configure `Access-Control-Allow-Headers` via
+  `CORS_RawAllowedHeaders` for CORS middleware in appkit/service
+  package.
+
 # PR [#39](https://github.com/theplant/appkit/pull/39)
 
 * Add monitoring InfluxDB client that sources InfluxDB credentials

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -135,6 +135,7 @@ type corsConfig struct {
 	RawAllowedOrigins string
 	AllowedOrigins    []string
 	AllowCredentials  bool
+	RawAllowedHeaders string
 }
 
 func corsMiddleware(logger log.Logger) server.Middleware {
@@ -150,6 +151,7 @@ func corsMiddleware(logger log.Logger) server.Middleware {
 			"msg", "not enabling CORS middleware: CORS configuration is blank",
 			"raw_allowed_origins", config.RawAllowedOrigins,
 			"allowed_credentials", config.AllowCredentials,
+			"raw_allowed_headers", config.RawAllowedHeaders,
 		)
 		return server.IdMiddleware
 	}
@@ -159,15 +161,22 @@ func corsMiddleware(logger log.Logger) server.Middleware {
 		config.AllowedOrigins[i] = strings.TrimSpace(allowedOrigin)
 	}
 
+	allowedHeaders := strings.Split(config.RawAllowedHeaders, ",")
+	for i, allowedHeader := range allowedHeaders {
+		allowedHeaders[i] = strings.TrimSpace(allowedHeader)
+	}
+
 	c := cors.New(cors.Options{
 		AllowedOrigins:   config.AllowedOrigins,
 		AllowCredentials: config.AllowCredentials,
+		AllowedHeaders:   allowedHeaders,
 	})
 
 	logger.Info().Log(
 		"msg", "enabling CORS middleware",
 		"allowed_origins", strings.Join(config.AllowedOrigins, ","),
 		"allow_credentials", config.AllowCredentials,
+		"allowed_headers", strings.Join(allowedHeaders, ","),
 	)
 
 	return c.Handler


### PR DESCRIPTION
This is a backward compatible change.

* Allow configure `Access-Control-Allow-Headers` via `CORS_RawAllowedHeaders` for CORS middleware in appkit/service package.