### PR TITLE
Add sampling to logtracing

### DIFF
--- a/logtracing/config.go
+++ b/logtracing/config.go
@@ -1,0 +1,36 @@
+package logtracing
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Config represents the global tracing configuration.
+type Config struct {
+	DefaultSampler Sampler
+	IDGenerator    IDGenerator
+}
+
+var configWriteMu sync.Mutex
+
+func ApplyConfig(cfg Config) {
+	configWriteMu.Lock()
+	defer configWriteMu.Unlock()
+	c := *config.Load().(*Config)
+	if cfg.DefaultSampler != nil {
+		c.DefaultSampler = cfg.DefaultSampler
+	}
+	if cfg.IDGenerator != nil {
+		c.IDGenerator = cfg.IDGenerator
+	}
+	config.Store(&c)
+}
+
+var config atomic.Value // access atomically
+
+func init() {
+	config.Store(&Config{
+		DefaultSampler: AlwaysSample(),
+		IDGenerator:    defaultIDGenerator(),
+	})
+}

--- a/logtracing/id_generator.go
+++ b/logtracing/id_generator.go
@@ -42,17 +42,3 @@ func defaultIDGenerator() IDGenerator {
 	gen.randSource = rand.New(rand.NewSource(rngSeed))
 	return gen
 }
-
-var _idGenerator IDGenerator
-
-func init() {
-	_idGenerator = defaultIDGenerator()
-}
-
-func GetIDGenerator() IDGenerator {
-	return _idGenerator
-}
-
-func SetIDGenerator(idGenerator IDGenerator) {
-	_idGenerator = idGenerator
-}

--- a/logtracing/sampling.go
+++ b/logtracing/sampling.go
@@ -1,0 +1,43 @@
+package logtracing
+
+import (
+	"encoding/binary"
+)
+
+type Sampler func(SamplingParameters) bool
+
+type SamplingParameters struct {
+	ParentMeta SpanMeta
+	TraceID    TraceID
+	SpanID     SpanID
+	Name       string
+}
+
+func ProbabilitySampler(fraction float64) Sampler {
+	if !(fraction >= 0) {
+		fraction = 0
+	} else if fraction >= 1 {
+		return AlwaysSample()
+	}
+
+	traceIDUpperBound := uint64(fraction * (1 << 63))
+	return Sampler(func(p SamplingParameters) bool {
+		if p.ParentMeta.IsSampled {
+			return true
+		}
+		x := binary.BigEndian.Uint64(p.TraceID[0:8]) >> 1
+		return x < traceIDUpperBound
+	})
+}
+
+func AlwaysSample() Sampler {
+	return func(p SamplingParameters) bool {
+		return true
+	}
+}
+
+func NeverSample() Sampler {
+	return func(p SamplingParameters) bool {
+		return false
+	}
+}

--- a/logtracing/sampling.go
+++ b/logtracing/sampling.go
@@ -7,7 +7,7 @@ import (
 type Sampler func(SamplingParameters) bool
 
 type SamplingParameters struct {
-	ParentMeta SpanMeta
+	ParentMeta spanMeta
 	TraceID    TraceID
 	SpanID     SpanID
 	Name       string

--- a/logtracing/span.go
+++ b/logtracing/span.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-type SpanMeta struct {
+type spanMeta struct {
 	TraceID   TraceID
 	SpanID    SpanID
 	Name      string
@@ -82,8 +82,8 @@ func (s *span) AppendKVs(keyvals ...interface{}) {
 	s.keyvals = append(s.keyvals, keyvals...)
 }
 
-func (s *span) Meta() SpanMeta {
-	return SpanMeta{
+func (s *span) meta() spanMeta {
+	return spanMeta{
 		TraceID:   s.traceID,
 		SpanID:    s.spanID,
 		Name:      s.name,

--- a/logtracing/span.go
+++ b/logtracing/span.go
@@ -9,12 +9,20 @@ import (
 	"time"
 )
 
+type SpanMeta struct {
+	TraceID   TraceID
+	SpanID    SpanID
+	Name      string
+	IsSampled bool
+}
+
 type span struct {
 	parent *span
 
-	traceID TraceID
-	spanID  SpanID
-	name    string
+	traceID   TraceID
+	spanID    SpanID
+	name      string
+	isSampled bool
 
 	startTime time.Time
 	endTime   time.Time
@@ -72,6 +80,15 @@ func (s *span) AppendKVs(keyvals ...interface{}) {
 	defer s.mu.Unlock()
 
 	s.keyvals = append(s.keyvals, keyvals...)
+}
+
+func (s *span) Meta() SpanMeta {
+	return SpanMeta{
+		TraceID:   s.traceID,
+		SpanID:    s.spanID,
+		Name:      s.name,
+		IsSampled: s.isSampled,
+	}
 }
 
 // TraceID is a unique identity of a trace.

--- a/logtracing/span.go
+++ b/logtracing/span.go
@@ -12,9 +12,9 @@ import (
 type span struct {
 	parent *span
 
-	traceID     TraceID
-	spanID      SpanID
-	spanContext string
+	traceID TraceID
+	spanID  SpanID
+	name    string
 
 	startTime time.Time
 	endTime   time.Time

--- a/logtracing/trace.go
+++ b/logtracing/trace.go
@@ -63,9 +63,9 @@ func StartSpan(ctx context.Context, name string) (context.Context, *span) {
 	s := span{
 		parent: parent,
 
-		traceID:     traceID,
-		spanID:      spanID,
-		spanContext: name,
+		traceID: traceID,
+		spanID:  spanID,
+		name:    name,
 
 		startTime: time.Now(),
 	}
@@ -113,7 +113,7 @@ func LogSpan(ctx context.Context, s *span) {
 		"ts", s.startTime.Format(time.RFC3339Nano),
 		"trace.id", s.traceID,
 		"span.id", s.spanID,
-		"span.context", s.spanContext,
+		"span.context", s.name,
 		"span.dur_ms", dur.Milliseconds(),
 	)
 
@@ -125,7 +125,7 @@ func LogSpan(ctx context.Context, s *span) {
 
 	if s.err != nil {
 		keyvals = append(keyvals,
-			"msg", fmt.Sprintf("%s (%v) -> %s (%T)", s.spanContext, dur, s.err, s.err),
+			"msg", fmt.Sprintf("%s (%v) -> %s (%T)", s.name, dur, s.err, s.err),
 			"span.err", s.err,
 			"span.err_type", errType(s.err),
 			"span.with_err", 1,
@@ -136,7 +136,7 @@ func LogSpan(ctx context.Context, s *span) {
 
 	if s.panic != nil {
 		keyvals = append(keyvals,
-			"msg", fmt.Sprintf("%s (%v) -> panic: %s (%T)", s.spanContext, dur, s.err, s.err),
+			"msg", fmt.Sprintf("%s (%v) -> panic: %s (%T)", s.name, dur, s.err, s.err),
 			"span.panic", s.panic,
 			"span.panic_type", errType(s.err),
 			"span.with_panic", 1,
@@ -147,7 +147,7 @@ func LogSpan(ctx context.Context, s *span) {
 	}
 
 	keyvals = append(keyvals,
-		"msg", fmt.Sprintf("%s (%v) -> success", s.spanContext, dur),
+		"msg", fmt.Sprintf("%s (%v) -> success", s.name, dur),
 	)
 	l.Info().Log(keyvals...)
 }

--- a/logtracing/trace.go
+++ b/logtracing/trace.go
@@ -155,8 +155,11 @@ func LogSpan(ctx context.Context, s *span) {
 		"span.id", s.spanID,
 		"span.context", s.name,
 		"span.dur_ms", dur.Milliseconds(),
-		"span.is_sampled", s.isSampled,
 	)
+
+	if s.isSampled {
+		keyvals = append(keyvals, "span.is_sampled", 1)
+	}
 
 	if s.parent != nil {
 		keyvals = append(keyvals, "span.parent_id", s.parent.spanID)

--- a/logtracing/trace.go
+++ b/logtracing/trace.go
@@ -86,9 +86,9 @@ func StartSpan(ctx context.Context, name string, o ...StartOption) (context.Cont
 			sampler = opts.Sampler
 		}
 
-		var parentMeta SpanMeta
+		var parentMeta spanMeta
 		if parent != nil {
-			parentMeta = parent.Meta()
+			parentMeta = parent.meta()
 		}
 
 		isSampled = sampler(SamplingParameters{

--- a/logtracing/trace_func_test.go
+++ b/logtracing/trace_func_test.go
@@ -24,7 +24,7 @@ func TestTraceFunc(t *testing.T) {
 		t.Fatalf("span should be in context")
 	}
 
-	if s.spanContext != "test" {
+	if s.name != "test" {
 		t.Fatalf("span context should be the same as the name")
 	}
 

--- a/logtracing/trace_http.go
+++ b/logtracing/trace_http.go
@@ -22,6 +22,7 @@ func TraceHTTPRequest(do func(*http.Request) (*http.Response, error), baseName s
 	AppendSpanKVs(ctx,
 		HTTPClientKVs(req)...,
 	)
+	req = req.WithContext(ctx)
 	resp, err = do(req)
 	if err == nil {
 		AppendSpanKVs(ctx,

--- a/logtracing/trace_test.go
+++ b/logtracing/trace_test.go
@@ -121,3 +121,12 @@ func TestTrace(t *testing.T) {
 		t.Fatalf("span should have 6 keyvals, but got %v", len(span3.keyvals))
 	}
 }
+
+func TestTraceWithNeverSampler(t *testing.T) {
+	ctx := context.Background()
+	ctx, span := StartSpan(ctx, "test", WithSampler(NeverSample()))
+	defer func() { EndSpan(ctx, nil) }()
+	if span.isSampled {
+		t.Fatalf("span should not be sampled")
+	}
+}

--- a/logtracing/trace_test.go
+++ b/logtracing/trace_test.go
@@ -29,7 +29,7 @@ func TestStartSpanWithoutParent(t *testing.T) {
 	if s == nil {
 		t.Fatalf("span should not be nil")
 	}
-	if s.spanContext != "top-level" {
+	if s.name != "top-level" {
 		t.Fatalf("span context should be the same as the name")
 	}
 	if len(s.traceID) == 0 {
@@ -58,7 +58,7 @@ func TestStartSpanWithParent(t *testing.T) {
 	if secondLevelS == nil {
 		t.Fatalf("span should not be nil")
 	}
-	if secondLevelS.spanContext != "second-level" {
+	if secondLevelS.name != "second-level" {
 		t.Fatalf("span context should be the same as the name")
 	}
 	if len(secondLevelS.traceID) == 0 {


### PR DESCRIPTION
These features have been added to `logtracing`:
1. Set up the default sampler
2. Set up a sampler when starting a new span
3. Log a sampled span with tag `is_sampled=1`