### PR TITLE
logtracing: record panic

### DIFF
--- a/logtracing/README.md
+++ b/logtracing/README.md
@@ -31,7 +31,7 @@ You can append key-values to an active span with `AppendSpanKvs`:
 func DoWork(ctx context.Context) err error {
 	ctx, _ := logtracing.StartSpan(ctx, "<span.context>")
 	defer func() { logtracing.EndSpan(ctx, err) }()
-  defer RecordPanic(ctx)
+	defer RecordPanic(ctx)
 
 	logtracing.AppendSpanKVs(ctx,
 		"service", "greeter",
@@ -47,8 +47,8 @@ func DoWork(ctx context.Context) err error {
 	ctx = logtracing.ContextWithKVs(ctx, "key", "value")
 
 	ctx, _ = logtracing.StartSpan(ctx, "test")
-  defer func() { logtracing.EndSpan(ctx, err) }()
-  defer RecordPanic(ctx)
+	defer func() { logtracing.EndSpan(ctx, err) }()
+	defer RecordPanic(ctx)
 }
 ```
 

--- a/logtracing/README.md
+++ b/logtracing/README.md
@@ -1,4 +1,4 @@
-# logtracing
+****# logtracing
 
 This package is a toolkit for log-based tracing. It provides several APIs for adding traces for the application and logging them in a standard format.
 
@@ -10,12 +10,16 @@ Import the package
 import 'github.com/theplant/appkit/logtracing'
 ```
 
-Inside a function, you can use these two APIs to track it:
+Inside a function, you can use these three APIs to track it:
+- `StartSpan(context.Context, string)` to start a span
+- `EndSpan(context.Context, error)` to end the span, also log it in an agreed format
+- `RecordPanic(context.Context)` to record the panic into the span
 
 ```
 func DoWork(ctx context.Context) err error {
 	ctx, _ := logtracing.StartSpan(ctx, "<span.context>")
 	defer func() { logtracing.EndSpan(ctx, err) }()
+	defer RecordPanic(ctx)
 }
 ```
 
@@ -27,6 +31,7 @@ You can append key-values to an active span with `AppendSpanKvs`:
 func DoWork(ctx context.Context) err error {
 	ctx, _ := logtracing.StartSpan(ctx, "<span.context>")
 	defer func() { logtracing.EndSpan(ctx, err) }()
+  defer RecordPanic(ctx)
 
 	logtracing.AppendSpanKVs(ctx,
 		"service", "greeter",
@@ -42,6 +47,8 @@ func DoWork(ctx context.Context) err error {
 	ctx = logtracing.ContextWithKVs(ctx, "key", "value")
 
 	ctx, _ = logtracing.StartSpan(ctx, "test")
+  defer func() { logtracing.EndSpan(ctx, err) }()
+  defer RecordPanic(ctx)
 }
 ```
 

--- a/logtracing/trace.go
+++ b/logtracing/trace.go
@@ -189,7 +189,7 @@ func LogSpan(ctx context.Context, s *span) {
 	if s.panic != nil {
 		keyvals = append(keyvals,
 			"msg", fmt.Sprintf("%s (%v) -> panic: %+v (%T)", s.name, dur, s.panic, s.panic),
-			"span.panic", s.panic,
+			"span.panic", fmt.Sprintf("%s", s.panic),
 			"span.panic_type", errType(s.panic),
 			"span.with_panic", 1,
 			"span.with_err", 1,
@@ -201,7 +201,7 @@ func LogSpan(ctx context.Context, s *span) {
 	if s.err != nil {
 		keyvals = append(keyvals,
 			"msg", fmt.Sprintf("%s (%v) -> error: %+v (%T)", s.name, dur, s.err, s.err),
-			"span.err", s.err,
+			"span.err", s.err.Error(),
 			"span.err_type", errType(s.err),
 			"span.with_err", 1,
 		)

--- a/logtracing/trace.go
+++ b/logtracing/trace.go
@@ -186,26 +186,26 @@ func LogSpan(ctx context.Context, s *span) {
 
 	keyvals = append(keyvals, s.keyvals...)
 
+	if s.panic != nil {
+		keyvals = append(keyvals,
+			"msg", fmt.Sprintf("%s (%v) -> panic: %s (%T)", s.name, dur, s.panic, s.panic),
+			"span.panic", s.panic,
+			"span.panic_type", errType(s.panic),
+			"span.with_panic", 1,
+			"span.with_err", 1,
+		)
+		l.Crit().Log(keyvals...)
+		return
+	}
+
 	if s.err != nil {
 		keyvals = append(keyvals,
-			"msg", fmt.Sprintf("%s (%v) -> %s (%T)", s.name, dur, s.err, s.err),
+			"msg", fmt.Sprintf("%s (%v) -> error: %s (%T)", s.name, dur, s.err, s.err),
 			"span.err", s.err,
 			"span.err_type", errType(s.err),
 			"span.with_err", 1,
 		)
 		l.Error().Log(keyvals...)
-		return
-	}
-
-	if s.panic != nil {
-		keyvals = append(keyvals,
-			"msg", fmt.Sprintf("%s (%v) -> panic: %s (%T)", s.name, dur, s.err, s.err),
-			"span.panic", s.panic,
-			"span.panic_type", errType(s.err),
-			"span.with_panic", 1,
-			"span.with_err", 1,
-		)
-		l.Crit().Log(keyvals...)
 		return
 	}
 

--- a/logtracing/trace.go
+++ b/logtracing/trace.go
@@ -188,7 +188,7 @@ func LogSpan(ctx context.Context, s *span) {
 
 	if s.panic != nil {
 		keyvals = append(keyvals,
-			"msg", fmt.Sprintf("%s (%v) -> panic: %s (%T)", s.name, dur, s.panic, s.panic),
+			"msg", fmt.Sprintf("%s (%v) -> panic: %+v (%T)", s.name, dur, s.panic, s.panic),
 			"span.panic", s.panic,
 			"span.panic_type", errType(s.panic),
 			"span.with_panic", 1,
@@ -200,7 +200,7 @@ func LogSpan(ctx context.Context, s *span) {
 
 	if s.err != nil {
 		keyvals = append(keyvals,
-			"msg", fmt.Sprintf("%s (%v) -> error: %s (%T)", s.name, dur, s.err, s.err),
+			"msg", fmt.Sprintf("%s (%v) -> error: %+v (%T)", s.name, dur, s.err, s.err),
 			"span.err", s.err,
 			"span.err_type", errType(s.err),
 			"span.with_err", 1,

--- a/logtracing/trace_func.go
+++ b/logtracing/trace_func.go
@@ -5,6 +5,7 @@ import "context"
 func TraceFunc(ctx context.Context, name string, f func(context.Context) error) (err error) {
 	ctx, _ = StartSpan(ctx, name)
 	defer func() { EndSpan(ctx, err) }()
+	defer RecordPanic(ctx)
 
 	return f(ctx)
 }

--- a/logtracing/trace_grpc.go
+++ b/logtracing/trace_grpc.go
@@ -68,6 +68,7 @@ func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 			AppendSpanKVs(ctx, "grpc.code", status.Code(err).String())
 			EndSpan(ctx, err)
 		}()
+		defer RecordPanic(ctx)
 		AppendSpanKVs(ctx, GRPCServerKVs(service, method)...)
 
 		return handler(ctx, req)
@@ -82,6 +83,7 @@ func StreamServerInterceptor() grpc.StreamServerInterceptor {
 			AppendSpanKVs(ctx, "grpc.code", status.Code(err).String())
 			EndSpan(ctx, err)
 		}()
+		defer RecordPanic(ctx)
 		AppendSpanKVs(ctx, GRPCClientKVs(service, method)...)
 
 		wrapped := grpc_middleware.WrapServerStream(stream)

--- a/logtracing/trace_grpc_test.go
+++ b/logtracing/trace_grpc_test.go
@@ -19,7 +19,7 @@ type greeterServer struct {
 	greeter.UnimplementedGreeterServer
 }
 
-var panicErr = errors.New("Danger!")
+var grpcPanicErr = errors.New("Danger!")
 
 func (s *greeterServer) SayHello(ctx context.Context, in *greeter.HelloRequest) (*greeter.HelloReply, error) {
 	if in.Name == "It" {
@@ -27,7 +27,7 @@ func (s *greeterServer) SayHello(ctx context.Context, in *greeter.HelloRequest) 
 	}
 
 	if in.Name == "W.W." {
-		panic(panicErr)
+		panic(grpcPanicErr)
 	}
 
 	return &greeter.HelloReply{Message: "Hello " + in.Name}, nil
@@ -47,10 +47,10 @@ func startGreeterServer(t *testing.T) {
 	lis = bufconn.Listen(bufSize)
 
 	recoveryHandler := func(p interface{}) (err error) {
-		if p != panicErr {
+		if p != grpcPanicErr {
 			t.Fatalf("should be panic err")
 		}
-		return panicErr
+		return grpcPanicErr
 	}
 	_grpcServer = grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
@@ -113,7 +113,7 @@ func TestSayHello(t *testing.T) {
 
 	_, err = greeterClient.SayHello(ctx, &greeter.HelloRequest{Name: "W.W."})
 	status, _ := status.FromError(err)
-	if status.Message() != panicErr.Error() {
+	if status.Message() != grpcPanicErr.Error() {
 		t.Fatalf("Should return panic err, actual: %s", status.Message())
 	}
 }

--- a/logtracing/trace_http.go
+++ b/logtracing/trace_http.go
@@ -19,6 +19,7 @@ func HTTPClientKVs(req *http.Request) []interface{} {
 func TraceHTTPRequest(do func(*http.Request) (*http.Response, error), baseName string, req *http.Request) (resp *http.Response, err error) {
 	ctx, _ := StartSpan(req.Context(), httpClientRequestName(baseName, req))
 	defer func() { EndSpan(ctx, err) }()
+	defer RecordPanic(ctx)
 	AppendSpanKVs(ctx,
 		HTTPClientKVs(req)...,
 	)

--- a/logtracing/trace_http_test.go
+++ b/logtracing/trace_http_test.go
@@ -1,6 +1,7 @@
 package logtracing
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 )
@@ -11,7 +12,17 @@ func TestTraceHTTPRequest(t *testing.T) {
 		t.Fatalf("err should be nil")
 	}
 
+	var s *span
 	resp, err := TraceHTTPRequest(func(r *http.Request) (*http.Response, error) {
+		s = SpanFromContext(r.Context())
+		if s == nil {
+			t.Fatalf("span should not be nil")
+		}
+
+		if s.name != "testTraceHTTPRequest.call(/hello)" {
+			t.Fatalf("span context should be testTraceHTTPRequest, actual: %s", s.name)
+		}
+
 		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK"}, nil
 	}, "testTraceHTTPRequest", req)
 
@@ -22,4 +33,24 @@ func TestTraceHTTPRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err should be nil")
 	}
+
+	panicErr := errors.New("I'm the danger")
+
+	defer func() {
+		recovered := recover()
+		if recovered != panicErr {
+			t.Fatalf("should receive panic")
+		}
+
+		if s.panic != panicErr {
+			t.Fatalf("panic should be recorded in span")
+		}
+	}()
+
+	func() {
+		resp, err = TraceHTTPRequest(func(r *http.Request) (*http.Response, error) {
+			s = SpanFromContext(r.Context())
+			panic(panicErr)
+		}, "panicedRequest", req)
+	}()
 }

--- a/logtracing/trace_test.go
+++ b/logtracing/trace_test.go
@@ -118,6 +118,30 @@ func TestEndSpan(t *testing.T) {
 	}
 }
 
+func TestRecordPanic(t *testing.T) {
+	ctx := context.Background()
+	err := errors.New("I'm panic!")
+
+	defer func() {
+		recovered := recover()
+		if recovered != err {
+			t.Fatalf("should receive panic")
+		}
+
+		s := SpanFromContext(ctx)
+		if s.panic != err {
+			t.Fatalf("panic should be recorded in span")
+		}
+	}()
+
+	func() {
+		ctx, _ = StartSpan(ctx, "test")
+		defer RecordPanic(ctx)
+
+		panic(err)
+	}()
+}
+
 func TestTrace(t *testing.T) {
 
 	ctx := context.Background()

--- a/logtracing/trace_test.go
+++ b/logtracing/trace_test.go
@@ -120,7 +120,7 @@ func TestEndSpan(t *testing.T) {
 
 func TestRecordPanic(t *testing.T) {
 	ctx := context.Background()
-	err := errors.New("I'm panic!")
+	err := errors.New("I'm the danger!")
 
 	defer func() {
 		recovered := recover()


### PR DESCRIPTION
1. Add a function `RecordPanic(ctx context.Context)` to record the panic to span and continue the panic.
2. If a panic is recorded in a span, the span log will be like:
    ```json
    {
      "caller": "trace.go:142",
      "level": "error",
      "msg": "panicerFN (8.186µs) -\u003e panic: I'm the danger! (*errors.errorString)",
      "span.context": "panicerFN",
      "span.dur_ms": 0,
      "span.id": "bd062d64444b7e7a",
      "span.is_sampled": 1,
      "span.panic": "I'm the danger!",
      "span.panic_type": "*errors.errorString",
      "span.with_err": 1,
      "span.with_panic": 1,
      "trace.id": "89961131c238fe260864f3b8011cbe85",
      "ts": "2022-11-03T18:24:38.732548+08:00"
    }
    ```
3. Add `RecordPanic` to the helper functions: `TraceFunc`, GRPC server interceptors, HTTP request helper