### PR TITLE
logtracing: add a start option `WIthStartTime`

### DIFF
--- a/logtracing/config.go
+++ b/logtracing/config.go
@@ -3,10 +3,13 @@ package logtracing
 import (
 	"sync"
 	"sync/atomic"
+
+	"github.com/theplant/appkit/log"
 )
 
 // Config represents the global tracing configuration.
 type Config struct {
+	DefaultLogger  *log.Logger
 	DefaultSampler Sampler
 	IDGenerator    IDGenerator
 }
@@ -17,6 +20,9 @@ func ApplyConfig(cfg Config) {
 	configWriteMu.Lock()
 	defer configWriteMu.Unlock()
 	c := *config.Load().(*Config)
+	if cfg.DefaultLogger != nil {
+		c.DefaultLogger = cfg.DefaultLogger
+	}
 	if cfg.DefaultSampler != nil {
 		c.DefaultSampler = cfg.DefaultSampler
 	}

--- a/logtracing/config.go
+++ b/logtracing/config.go
@@ -3,13 +3,10 @@ package logtracing
 import (
 	"sync"
 	"sync/atomic"
-
-	"github.com/theplant/appkit/log"
 )
 
 // Config represents the global tracing configuration.
 type Config struct {
-	DefaultLogger  *log.Logger
 	DefaultSampler Sampler
 	IDGenerator    IDGenerator
 }
@@ -20,9 +17,6 @@ func ApplyConfig(cfg Config) {
 	configWriteMu.Lock()
 	defer configWriteMu.Unlock()
 	c := *config.Load().(*Config)
-	if cfg.DefaultLogger != nil {
-		c.DefaultLogger = cfg.DefaultLogger
-	}
 	if cfg.DefaultSampler != nil {
 		c.DefaultSampler = cfg.DefaultSampler
 	}

--- a/logtracing/span.go
+++ b/logtracing/span.go
@@ -34,14 +34,6 @@ type span struct {
 	mu      sync.Mutex
 }
 
-// NOTE Could be used for integrating with other frameworks, like GORM
-func (s *span) AdjustStartTime(newStartTime time.Time) {
-	if !s.IsRecording() {
-		return
-	}
-	s.startTime = newStartTime
-}
-
 func (s *span) IsRecording() bool {
 	return s.endTime.IsZero()
 }

--- a/logtracing/trace.go
+++ b/logtracing/trace.go
@@ -163,10 +163,21 @@ func RecordPanic(ctx context.Context) {
 
 func LogSpan(ctx context.Context, s *span) {
 	var (
-		l       = log.ForceContext(ctx)
+		l       log.Logger
 		keyvals []interface{}
 		dur     = s.Duration()
 	)
+
+	if ctxLogger, ok := log.FromContext(ctx); ok {
+		l = ctxLogger
+	} else {
+		cfg := config.Load().(*Config)
+		if cfg.DefaultLogger != nil {
+			l = *cfg.DefaultLogger
+		} else {
+			l = log.Default()
+		}
+	}
 
 	keyvals = append(keyvals,
 		"ts", s.startTime.Format(time.RFC3339Nano),

--- a/logtracing/trace.go
+++ b/logtracing/trace.go
@@ -46,7 +46,8 @@ func contextWithSpan(parent context.Context, s *span) context.Context {
 }
 
 type StartOptions struct {
-	Sampler Sampler
+	Sampler   Sampler
+	StartTime time.Time
 }
 
 type StartOption func(*StartOptions)
@@ -54,6 +55,12 @@ type StartOption func(*StartOptions)
 func WithSampler(sampler Sampler) StartOption {
 	return func(o *StartOptions) {
 		o.Sampler = sampler
+	}
+}
+
+func WithStartTime(t time.Time) StartOption {
+	return func(o *StartOptions) {
+		o.StartTime = t
 	}
 }
 
@@ -67,6 +74,7 @@ func StartSpan(ctx context.Context, name string, o ...StartOption) (context.Cont
 		traceID   TraceID
 		spanID    = idGenerator.NewSpanID()
 		isSampled bool
+		startTime time.Time
 	)
 
 	for _, op := range o {
@@ -99,6 +107,12 @@ func StartSpan(ctx context.Context, name string, o ...StartOption) (context.Cont
 		})
 	}
 
+	if opts.StartTime.IsZero() {
+		startTime = time.Now()
+	} else {
+		startTime = opts.StartTime
+	}
+
 	s := span{
 		parent: parent,
 
@@ -107,7 +121,7 @@ func StartSpan(ctx context.Context, name string, o ...StartOption) (context.Cont
 		name:      name,
 		isSampled: isSampled,
 
-		startTime: time.Now(),
+		startTime: startTime,
 	}
 
 	ctxKVs := KVsFromContext(ctx)

--- a/logtracing/trace.go
+++ b/logtracing/trace.go
@@ -163,21 +163,10 @@ func RecordPanic(ctx context.Context) {
 
 func LogSpan(ctx context.Context, s *span) {
 	var (
-		l       log.Logger
+		l       = getLogger(ctx)
 		keyvals []interface{}
 		dur     = s.Duration()
 	)
-
-	if ctxLogger, ok := log.FromContext(ctx); ok {
-		l = ctxLogger
-	} else {
-		cfg := config.Load().(*Config)
-		if cfg.DefaultLogger != nil {
-			l = *cfg.DefaultLogger
-		} else {
-			l = log.Default()
-		}
-	}
 
 	keyvals = append(keyvals,
 		"ts", s.startTime.Format(time.RFC3339Nano),
@@ -224,6 +213,23 @@ func LogSpan(ctx context.Context, s *span) {
 		"msg", fmt.Sprintf("%s (%v) -> success", s.name, dur),
 	)
 	l.Info().Log(keyvals...)
+}
+
+func getLogger(ctx context.Context) log.Logger {
+	var l log.Logger
+
+	if ctxLogger, ok := log.FromContext(ctx); ok {
+		l = ctxLogger
+	} else {
+		cfg := config.Load().(*Config)
+		if cfg.DefaultLogger != nil {
+			l = *cfg.DefaultLogger
+		} else {
+			l = log.Default()
+		}
+	}
+
+	return l
 }
 
 type causer interface {

--- a/logtracing/trace.go
+++ b/logtracing/trace.go
@@ -235,12 +235,7 @@ func getLogger(ctx context.Context) log.Logger {
 	if ctxLogger, ok := log.FromContext(ctx); ok {
 		l = ctxLogger
 	} else {
-		cfg := config.Load().(*Config)
-		if cfg.DefaultLogger != nil {
-			l = *cfg.DefaultLogger
-		} else {
-			l = log.Default()
-		}
+		l = log.Default()
 	}
 
 	return l

--- a/logtracing/trace_test.go
+++ b/logtracing/trace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/theplant/appkit/log"
 	"github.com/theplant/testingutils/fatalassert"
@@ -220,4 +221,10 @@ func TestGetLogger(t *testing.T) {
 	ctxLogger := log.Default().With("name", "ctx")
 	ctx := log.Context(context.Background(), ctxLogger)
 	fatalassert.Equal(t, ctxLogger, getLogger((ctx)))
+}
+
+func TestWithStartTime(t *testing.T) {
+	ti := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, s := StartSpan(context.Background(), "test", WithStartTime(ti))
+	fatalassert.Equal(t, s.startTime, ti)
 }

--- a/logtracing/trace_test.go
+++ b/logtracing/trace_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/theplant/appkit/log"
+	"github.com/theplant/testingutils/fatalassert"
 )
 
 func BenchmarkTracing(b *testing.B) {
@@ -205,4 +206,18 @@ func TestChildrenAreSampledAsParent(t *testing.T) {
 	if !cspan.isSampled {
 		t.Fatalf("child span should be sampled")
 	}
+}
+
+func TestGetLogger(t *testing.T) {
+	fatalassert.NotNil(t, getLogger(context.Background()).Logger)
+
+	defaultLogger := log.Default().With("name", "default")
+	ApplyConfig(Config{
+		DefaultLogger: &defaultLogger,
+	})
+	fatalassert.Equal(t, defaultLogger, getLogger(context.Background()))
+
+	ctxLogger := log.Default().With("name", "ctx")
+	ctx := log.Context(context.Background(), ctxLogger)
+	fatalassert.Equal(t, ctxLogger, getLogger((ctx)))
 }

--- a/logtracing/trace_test.go
+++ b/logtracing/trace_test.go
@@ -212,12 +212,6 @@ func TestChildrenAreSampledAsParent(t *testing.T) {
 func TestGetLogger(t *testing.T) {
 	fatalassert.NotNil(t, getLogger(context.Background()).Logger)
 
-	defaultLogger := log.Default().With("name", "default")
-	ApplyConfig(Config{
-		DefaultLogger: &defaultLogger,
-	})
-	fatalassert.Equal(t, defaultLogger, getLogger(context.Background()))
-
 	ctxLogger := log.Default().With("name", "ctx")
 	ctx := log.Context(context.Background(), ctxLogger)
 	fatalassert.Equal(t, ctxLogger, getLogger((ctx)))


### PR DESCRIPTION
- Add a config `DefaultLogger`: to specify a logger, used when there is no other logger in the context
- Add a start option `WithStartTime`: to adjust the start time of a span