### PR TITLE
Add raw X-Forwarded-For header and RemoteAddr

### DIFF
--- a/logtracing/trace_http.go
+++ b/logtracing/trace_http.go
@@ -54,6 +54,8 @@ func HTTPServerKVs(req *http.Request) []interface{} {
 		"http.path", req.URL.Path,
 		"http.query_string", req.URL.RawQuery,
 		"http.user_agent", req.UserAgent(),
+		"http.x_forwarded_for", strings.Join(req.Header.Values("X-Forwarded-For"), ", "),
+		"http.remote_addr", req.RemoteAddr,
 		"http.client_ip", clientIP(req),
 	}
 }

--- a/server/logger_test.go
+++ b/server/logger_test.go
@@ -49,6 +49,9 @@ func TestLogRequest(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	req.Header.Add(traceHeaderKey, trace)
+	req.Header.Add("X-Forwarded-For", "192.168.1.1")
+	req.Header.Add("X-Forwarded-For", "192.168.2.1")
+	req.RemoteAddr = "192.168.3.1:12345"
 	h = Compose(
 		// Recovery should come before logReq to set the status code to 500
 		Recovery,


### PR DESCRIPTION
Logging both is usually better than only `clientIP`.

[clientIP](logtracing/trace_http.go:61) already prefers `X-Forwarded-For` and falls back to `req.RemoteAddr`, which is good for a single canonical field. But for debugging and security analysis, it helps to also log raw sources separately:

`http.x_forwarded_for`: raw header value
`http.remote_addr`: raw req.RemoteAddr

Why this is better:

1. You can audit spoofing/misconfig issues (`X-Forwarded-For` can be client-controlled unless trusted proxy strips/rewrites it).
2. You preserve provenance during incident review.
3. You still keep one easy field (`http.client_ip`) for dashboards/search.


```json
{"caller":"logger.go:89","client_ip":"192.168.1.1","context":"http","http.client_ip":"192.168.1.1","http.method":"GET","http.path":"","http.query_string":"","http.remote_addr":"192.168.3.1:12345","http.status":200,"http.user_agent":"","http.x_forwarded_for":"192.168.1.1, 192.168.2.1","level":"info","method":"GET","msg":"GET  (5.041µs) -> success","path":"","request_us":5,"span.context":"GET ","span.dur_ms":0,"span.id":"2f059858a740a0e1","span.is_sampled":1,"span.parent_id":"e80e9a7fee405552","span.role":"server","span.type":"http","status":200,"trace.id":"d4a7a8dab0d092c104144926e7e58605","ts":"2026-04-01T17:05:13.167783+08:00","user_agent":""}
```