### PR TITLE
feat: add configurable http.Server timeouts and statusWriter.Unwrap

### DIFF
--- a/contexts/contexts.go
+++ b/contexts/contexts.go
@@ -28,6 +28,14 @@ func (s *statusWriter) Flush() {
 	}
 }
 
+// Unwrap exposes the wrapped ResponseWriter so that http.ResponseController
+// can reach the underlying net.Conn (e.g. for SetReadDeadline /
+// SetWriteDeadline). Without this, per-request deadline control silently fails
+// once a handler is wrapped by WithHTTPStatus.
+func (s *statusWriter) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter
+}
+
 func WithHTTPStatus(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sw := &statusWriter{ResponseWriter: w}

--- a/contexts/contexts_test.go
+++ b/contexts/contexts_test.go
@@ -1,0 +1,136 @@
+package contexts
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// fakeWriter is a ResponseWriter that also supports the deadline and flush
+// capabilities of a real *http.response, recording whether each was reached.
+type fakeWriter struct {
+	header          http.Header
+	status          int
+	readDeadlineSet bool
+	flushed         bool
+}
+
+func (f *fakeWriter) Header() http.Header {
+	if f.header == nil {
+		f.header = http.Header{}
+	}
+	return f.header
+}
+func (f *fakeWriter) Write(b []byte) (int, error)     { return len(b), nil }
+func (f *fakeWriter) WriteHeader(status int)          { f.status = status }
+func (f *fakeWriter) Flush()                          { f.flushed = true }
+func (f *fakeWriter) SetReadDeadline(time.Time) error { f.readDeadlineSet = true; return nil }
+
+// Unwrap must return the same ResponseWriter that was wrapped, so the
+// http.ResponseController can walk down to the underlying connection.
+func TestStatusWriterUnwrap(t *testing.T) {
+	inner := &fakeWriter{}
+	sw := &statusWriter{ResponseWriter: inner}
+
+	if got := sw.Unwrap(); got != inner {
+		t.Fatalf("Unwrap: want wrapped writer %p, got %p", inner, got)
+	}
+}
+
+// http.ResponseController.SetReadDeadline must reach the underlying writer
+// through statusWriter's Unwrap. Before Unwrap existed this silently failed
+// with ErrNotSupported, which is why per-request read deadlines didn't work.
+func TestStatusWriterResponseControllerReachesDeadline(t *testing.T) {
+	inner := &fakeWriter{}
+	sw := &statusWriter{ResponseWriter: inner}
+
+	rc := http.NewResponseController(sw)
+	if err := rc.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline through statusWriter: %v", err)
+	}
+	if !inner.readDeadlineSet {
+		t.Fatal("SetReadDeadline did not reach the underlying writer")
+	}
+}
+
+// End-to-end through the real middleware: a handler wrapped by WithHTTPStatus
+// can still set a per-request read deadline via ResponseController. This is the
+// production entry point (WithHTTPStatus is in DefaultMiddleware).
+func TestWithHTTPStatusResponseControllerReachesDeadline(t *testing.T) {
+	inner := &fakeWriter{}
+
+	var handlerErr error
+	h := WithHTTPStatus(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerErr = http.NewResponseController(w).SetReadDeadline(time.Now().Add(time.Second))
+	}))
+
+	h.ServeHTTP(inner, httptest.NewRequest("GET", "/", nil))
+
+	if handlerErr != nil {
+		t.Fatalf("SetReadDeadline through WithHTTPStatus: %v", handlerErr)
+	}
+	if !inner.readDeadlineSet {
+		t.Fatal("SetReadDeadline did not reach the underlying writer")
+	}
+}
+
+// Regression: adding Unwrap must not break the SSE Flush support. Code that
+// type-asserts http.Flusher on the wrapped writer must still succeed, and
+// Flush must reach the underlying writer.
+func TestWithHTTPStatusExposesFlusher(t *testing.T) {
+	inner := &fakeWriter{}
+
+	var asserted bool
+	h := WithHTTPStatus(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f, ok := w.(http.Flusher)
+		asserted = ok
+		if ok {
+			f.Flush()
+		}
+	}))
+
+	h.ServeHTTP(inner, httptest.NewRequest("GET", "/", nil))
+
+	if !asserted {
+		t.Fatal("wrapped writer no longer satisfies http.Flusher")
+	}
+	if !inner.flushed {
+		t.Fatal("Flush did not reach the underlying writer")
+	}
+}
+
+// WithHTTPStatus records the status written by the handler, and HTTPStatus
+// defaults to 200 when the handler never calls WriteHeader.
+func TestWithHTTPStatusCapturesStatus(t *testing.T) {
+	cases := []struct {
+		desc  string
+		write int // 0 => don't call WriteHeader
+		want  int
+	}{
+		{desc: "explicit 404", write: http.StatusNotFound, want: http.StatusNotFound},
+		{desc: "default 200 when unwritten", write: 0, want: http.StatusOK},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			var got int
+			var ok bool
+			h := WithHTTPStatus(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if c.write != 0 {
+					w.WriteHeader(c.write)
+				}
+				got, ok = HTTPStatus(r.Context())
+			}))
+
+			h.ServeHTTP(&fakeWriter{}, httptest.NewRequest("GET", "/", nil))
+
+			if !ok {
+				t.Fatal("HTTPStatus reported no statusWriter in context")
+			}
+			if got != c.want {
+				t.Errorf("status: want %d, got %d", c.want, got)
+			}
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -14,14 +14,22 @@ import (
 )
 
 type Config struct {
-	Addr string `default:":9800"`
+	Addr              string `default:":9800"`
+	ReadTimeout       time.Duration
+	ReadHeaderTimeout time.Duration
+	WriteTimeout      time.Duration
+	IdleTimeout       time.Duration
 }
 
 func newServer(config Config, logger log.Logger, handler http.Handler) *http.Server {
 	server := http.Server{
-		Addr:     config.Addr,
-		ErrorLog: golog.New(log.LogWriter(logger.Error()), "", golog.Llongfile),
-		Handler:  handler,
+		Addr:              config.Addr,
+		ReadTimeout:       config.ReadTimeout,
+		ReadHeaderTimeout: config.ReadHeaderTimeout,
+		WriteTimeout:      config.WriteTimeout,
+		IdleTimeout:       config.IdleTimeout,
+		ErrorLog:          golog.New(log.LogWriter(logger.Error()), "", golog.Llongfile),
+		Handler:           handler,
 	}
 
 	return &server

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/theplant/appkit/log"
+)
+
+// By default (empty Config) no timeouts are set, so the http.Server keeps its
+// zero values and never times out. This preserves the previous behaviour for
+// services that don't opt in.
+func TestNewServerNoTimeoutsByDefault(t *testing.T) {
+	s := newServer(Config{Addr: ":9800"}, log.NewNopLogger(), nil)
+
+	if s.ReadTimeout != 0 {
+		t.Errorf("ReadTimeout: want 0, got %v", s.ReadTimeout)
+	}
+	if s.ReadHeaderTimeout != 0 {
+		t.Errorf("ReadHeaderTimeout: want 0, got %v", s.ReadHeaderTimeout)
+	}
+	if s.WriteTimeout != 0 {
+		t.Errorf("WriteTimeout: want 0, got %v", s.WriteTimeout)
+	}
+	if s.IdleTimeout != 0 {
+		t.Errorf("IdleTimeout: want 0, got %v", s.IdleTimeout)
+	}
+}
+
+// Each timeout in Config must map to its own field on the http.Server. Using
+// distinct values guards against copy-paste mistakes (e.g. ReadHeaderTimeout
+// accidentally taking ReadTimeout's value).
+func TestNewServerMapsTimeouts(t *testing.T) {
+	cfg := Config{
+		Addr:              ":9800",
+		ReadTimeout:       30 * time.Second,
+		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
+	s := newServer(cfg, log.NewNopLogger(), nil)
+
+	if s.ReadTimeout != cfg.ReadTimeout {
+		t.Errorf("ReadTimeout: want %v, got %v", cfg.ReadTimeout, s.ReadTimeout)
+	}
+	if s.ReadHeaderTimeout != cfg.ReadHeaderTimeout {
+		t.Errorf("ReadHeaderTimeout: want %v, got %v", cfg.ReadHeaderTimeout, s.ReadHeaderTimeout)
+	}
+	if s.WriteTimeout != cfg.WriteTimeout {
+		t.Errorf("WriteTimeout: want %v, got %v", cfg.WriteTimeout, s.WriteTimeout)
+	}
+	if s.IdleTimeout != cfg.IdleTimeout {
+		t.Errorf("IdleTimeout: want %v, got %v", cfg.IdleTimeout, s.IdleTimeout)
+	}
+}

--- a/service/envduration_test.go
+++ b/service/envduration_test.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/theplant/appkit/log"
+)
+
+func TestEnvDuration(t *testing.T) {
+	const name = "TEST_SERVER_READ_TIMEOUT"
+
+	cases := []struct {
+		desc string
+		set  bool
+		val  string
+		want time.Duration
+	}{
+		// Unset => 0 => timeout stays disabled (opt-in behaviour).
+		{desc: "unset", set: false, want: 0},
+		// Empty is treated the same as unset.
+		{desc: "empty", set: true, val: "", want: 0},
+		{desc: "valid seconds", set: true, val: "30s", want: 30 * time.Second},
+		{desc: "valid minutes", set: true, val: "2m", want: 2 * time.Minute},
+		{desc: "valid composite", set: true, val: "1m30s", want: 90 * time.Second},
+		// Invalid => 0 (logged), never a wrong non-zero value that could kill
+		// legitimate connections.
+		{desc: "invalid garbage", set: true, val: "not-a-duration", want: 0},
+		{desc: "invalid missing unit", set: true, val: "30", want: 0},
+	}
+
+	logger := log.NewNopLogger()
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			os.Unsetenv(name)
+			if c.set {
+				os.Setenv(name, c.val)
+				defer os.Unsetenv(name)
+			}
+
+			if got := envDuration(logger, name); got != c.want {
+				t.Errorf("envDuration(%q=%q): want %v, got %v", name, c.val, c.want, got)
+			}
+		})
+	}
+}

--- a/service/envduration_test.go
+++ b/service/envduration_test.go
@@ -24,10 +24,15 @@ func TestEnvDuration(t *testing.T) {
 		{desc: "valid seconds", set: true, val: "30s", want: 30 * time.Second},
 		{desc: "valid minutes", set: true, val: "2m", want: 2 * time.Minute},
 		{desc: "valid composite", set: true, val: "1m30s", want: 90 * time.Second},
+		// Explicit zero is a valid way to say "disabled".
+		{desc: "explicit zero", set: true, val: "0s", want: 0},
 		// Invalid => 0 (logged), never a wrong non-zero value that could kill
 		// legitimate connections.
 		{desc: "invalid garbage", set: true, val: "not-a-duration", want: 0},
 		{desc: "invalid missing unit", set: true, val: "30", want: 0},
+		// Negative parses fine but would make every request time out
+		// immediately, so it is rejected and treated as disabled.
+		{desc: "negative", set: true, val: "-5s", want: 0},
 	}
 
 	logger := log.NewNopLogger()

--- a/service/servertimeouts_test.go
+++ b/service/servertimeouts_test.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/theplant/appkit/log"
+)
+
+// Each SERVER_* env var must map to its own timeout. Distinct values per var
+// catch a mismapped field (e.g. SERVER_READ_TIMEOUT landing on WriteTimeout).
+func TestServerTimeoutsMapping(t *testing.T) {
+	envs := map[string]string{
+		"SERVER_READ_HEADER_TIMEOUT": "1s",
+		"SERVER_READ_TIMEOUT":        "2s",
+		"SERVER_WRITE_TIMEOUT":       "3s",
+		"SERVER_IDLE_TIMEOUT":        "4s",
+	}
+	for k, v := range envs {
+		os.Setenv(k, v)
+		defer os.Unsetenv(k)
+	}
+
+	readHeader, read, write, idle := serverTimeouts(log.NewNopLogger())
+
+	if readHeader != 1*time.Second {
+		t.Errorf("readHeader: want 1s, got %v", readHeader)
+	}
+	if read != 2*time.Second {
+		t.Errorf("read: want 2s, got %v", read)
+	}
+	if write != 3*time.Second {
+		t.Errorf("write: want 3s, got %v", write)
+	}
+	if idle != 4*time.Second {
+		t.Errorf("idle: want 4s, got %v", idle)
+	}
+}
+
+// With nothing configured all timeouts stay disabled (0), so services that
+// don't opt in are unaffected.
+func TestServerTimeoutsUnsetAllZero(t *testing.T) {
+	for _, k := range []string{
+		"SERVER_READ_HEADER_TIMEOUT",
+		"SERVER_READ_TIMEOUT",
+		"SERVER_WRITE_TIMEOUT",
+		"SERVER_IDLE_TIMEOUT",
+	} {
+		os.Unsetenv(k)
+	}
+
+	readHeader, read, write, idle := serverTimeouts(log.NewNopLogger())
+
+	if readHeader != 0 || read != 0 || write != 0 || idle != 0 {
+		t.Errorf("want all 0, got %v %v %v %v", readHeader, read, write, idle)
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/theplant/appkit/log"
@@ -18,6 +19,30 @@ func logErr(l log.Logger, f func() error) {
 	if err := f(); err != nil {
 		l.WithError(err).Log()
 	}
+}
+
+// envDuration reads a time.Duration (e.g. "30s") from the named environment
+// variable. It is opt-in: if the variable is unset it returns 0, leaving the
+// corresponding http.Server timeout disabled so services that don't configure
+// it keep the previous "no timeout" behaviour. If the variable is set but
+// cannot be parsed it logs a warning and returns 0, rather than silently
+// applying a wrong (and possibly connection-killing) value.
+func envDuration(logger log.Logger, name string) time.Duration {
+	v := os.Getenv(name)
+	if v == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		logger.Warn().Log(
+			"msg", fmt.Sprintf("ignoring invalid duration in %s: %q", name, v),
+			"env", name,
+			"value", v,
+			"err", err,
+		)
+		return 0
+	}
+	return d
 }
 
 func ContextAndMiddleware() (context.Context, server.Middleware, io.Closer, error) {
@@ -65,6 +90,13 @@ func ListenAndServe(app func(context.Context, *http.ServeMux) error) {
 		}
 		cfg.Addr = ":" + port
 	}
+
+	// http.Server timeouts, opt-in per service via env. Unset => 0 => disabled,
+	// preserving existing behaviour for services that don't configure them.
+	cfg.ReadHeaderTimeout = envDuration(logger, "SERVER_READ_HEADER_TIMEOUT")
+	cfg.ReadTimeout = envDuration(logger, "SERVER_READ_TIMEOUT")
+	cfg.WriteTimeout = envDuration(logger, "SERVER_WRITE_TIMEOUT")
+	cfg.IdleTimeout = envDuration(logger, "SERVER_IDLE_TIMEOUT")
 
 	hc := server.GoListenAndServe(
 		cfg,

--- a/service/service.go
+++ b/service/service.go
@@ -98,6 +98,14 @@ func ListenAndServe(app func(context.Context, *http.ServeMux) error) {
 	cfg.WriteTimeout = envDuration(logger, "SERVER_WRITE_TIMEOUT")
 	cfg.IdleTimeout = envDuration(logger, "SERVER_IDLE_TIMEOUT")
 
+	logger.Info().Log(
+		"msg", "configured http.Server timeouts (0 = disabled)",
+		"read_header_timeout", cfg.ReadHeaderTimeout,
+		"read_timeout", cfg.ReadTimeout,
+		"write_timeout", cfg.WriteTimeout,
+		"idle_timeout", cfg.IdleTimeout,
+	)
+
 	hc := server.GoListenAndServe(
 		cfg,
 		logger,

--- a/service/service.go
+++ b/service/service.go
@@ -114,13 +114,23 @@ func ListenAndServe(app func(context.Context, *http.ServeMux) error) {
 	// preserving existing behaviour for services that don't configure them.
 	cfg.ReadHeaderTimeout, cfg.ReadTimeout, cfg.WriteTimeout, cfg.IdleTimeout = serverTimeouts(logger)
 
-	logger.Info().Log(
-		"msg", "configured http.Server timeouts (0 = disabled)",
-		"read_header_timeout", cfg.ReadHeaderTimeout,
-		"read_timeout", cfg.ReadTimeout,
-		"write_timeout", cfg.WriteTimeout,
-		"idle_timeout", cfg.IdleTimeout,
-	)
+	// Log only the enabled (non-zero) timeouts.
+	kvs := []interface{}{"msg", "configured http.Server timeouts"}
+	if cfg.ReadHeaderTimeout > 0 {
+		kvs = append(kvs, "read_header_timeout", cfg.ReadHeaderTimeout)
+	}
+	if cfg.ReadTimeout > 0 {
+		kvs = append(kvs, "read_timeout", cfg.ReadTimeout)
+	}
+	if cfg.WriteTimeout > 0 {
+		kvs = append(kvs, "write_timeout", cfg.WriteTimeout)
+	}
+	if cfg.IdleTimeout > 0 {
+		kvs = append(kvs, "idle_timeout", cfg.IdleTimeout)
+	}
+	if len(kvs) > 2 {
+		logger.Info().Log(kvs...)
+	}
 
 	hc := server.GoListenAndServe(
 		cfg,

--- a/service/service.go
+++ b/service/service.go
@@ -25,8 +25,9 @@ func logErr(l log.Logger, f func() error) {
 // variable. It is opt-in: if the variable is unset it returns 0, leaving the
 // corresponding http.Server timeout disabled so services that don't configure
 // it keep the previous "no timeout" behaviour. If the variable is set but
-// cannot be parsed it logs a warning and returns 0, rather than silently
-// applying a wrong (and possibly connection-killing) value.
+// cannot be parsed, or is negative (a negative deadline would make every
+// request time out immediately), it logs a warning and returns 0, rather than
+// silently applying a wrong (and possibly connection-killing) value.
 func envDuration(logger log.Logger, name string) time.Duration {
 	v := os.Getenv(name)
 	if v == "" {
@@ -42,7 +43,25 @@ func envDuration(logger log.Logger, name string) time.Duration {
 		)
 		return 0
 	}
+	if d < 0 {
+		logger.Warn().Log(
+			"msg", fmt.Sprintf("ignoring negative duration in %s: %q", name, v),
+			"env", name,
+			"value", v,
+		)
+		return 0
+	}
 	return d
+}
+
+// serverTimeouts reads the opt-in http.Server timeouts from SERVER_* env vars.
+// Kept separate from ListenAndServe so the env-var-to-field wiring is unit
+// testable (a mismapped field would otherwise ship silently).
+func serverTimeouts(logger log.Logger) (readHeader, read, write, idle time.Duration) {
+	return envDuration(logger, "SERVER_READ_HEADER_TIMEOUT"),
+		envDuration(logger, "SERVER_READ_TIMEOUT"),
+		envDuration(logger, "SERVER_WRITE_TIMEOUT"),
+		envDuration(logger, "SERVER_IDLE_TIMEOUT")
 }
 
 func ContextAndMiddleware() (context.Context, server.Middleware, io.Closer, error) {
@@ -93,10 +112,7 @@ func ListenAndServe(app func(context.Context, *http.ServeMux) error) {
 
 	// http.Server timeouts, opt-in per service via env. Unset => 0 => disabled,
 	// preserving existing behaviour for services that don't configure them.
-	cfg.ReadHeaderTimeout = envDuration(logger, "SERVER_READ_HEADER_TIMEOUT")
-	cfg.ReadTimeout = envDuration(logger, "SERVER_READ_TIMEOUT")
-	cfg.WriteTimeout = envDuration(logger, "SERVER_WRITE_TIMEOUT")
-	cfg.IdleTimeout = envDuration(logger, "SERVER_IDLE_TIMEOUT")
+	cfg.ReadHeaderTimeout, cfg.ReadTimeout, cfg.WriteTimeout, cfg.IdleTimeout = serverTimeouts(logger)
 
 	logger.Info().Log(
 		"msg", "configured http.Server timeouts (0 = disabled)",


### PR DESCRIPTION
## Why

The `http.Server` built by `server.newServer` set none of `ReadTimeout`,`ReadHeaderTimeout`, `WriteTimeout` or `IdleTimeout`. A slow or stalled client— e.g. one that sends request headers but never sends the body — holds a handler goroutine until the upstream idle timeout (ALB, 60s) closes the connection. We hit this in production on a page-server API.

Separately, `contexts.statusWriter` (installed by `WithHTTPStatus`, part of `DefaultMiddleware`) embedded `http.ResponseWriter` without an `Unwrap`, so `http.ResponseController` could not reach the underlying `net.Conn` — per-request `SetReadDeadline`/`SetWriteDeadline` silently failed. This blocked the natural per-route fix.

## What

- **`server.Config`**: add `ReadTimeout`, `ReadHeaderTimeout`, `WriteTimeout`,  `IdleTimeout` and map them onto the `http.Server`.
- **`service.ListenAndServe`**: read these from `SERVER_*` env vars, log the effective values at startup. Invalid or negative values are logged and ignored (a negative deadline would make every request fail immediately).
- **`contexts.statusWriter`**: add `Unwrap()` so `ResponseController` deadlines work through the wrapper. Existing `Flush()` is kept.

## Backward compatibility

Fully backward compatible — nothing changes for current users:

- Timeouts are **opt-in**. Unset env var ⇒ `0` ⇒ disabled ⇒ identical to today's behaviour. Only services that set `SERVER_*` get timeouts.
- `Unwrap()` is purely additive. It does not change type assertions
  (`w.(http.Flusher)` / `w.(http.Hijacker)` are unaffected), and `Flush()` is retained so existing SSE callers keep working.

## How to use

Set on the service (e.g. ECS task definition):

SERVER_READ_HEADER_TIMEOUT=10s
SERVER_READ_TIMEOUT=30s
SERVER_WRITE_TIMEOUT=60s   # must exceed the slowest legitimate handler
SERVER_IDLE_TIMEOUT=120s   # keep larger than the A

Per-route overrides are now possible via
`http.NewResponseController(w).SetReadDeadline(...)` inside a route-scoped middleware.

## Testing

`go test ./server/ ./service/ ./contexts/` — added
`SERVER_*` env parsing (incl. invalid/negative/zero), the env-to-field wiring,
`Unwrap`, `ResponseController` reaching the connect and a Flusher regression guard.