### PR TITLE
fix(ci): disable credential persistence in actions/checkout

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
## Problem

`actions/checkout` defaults to `persist-credentials: true`, which writes the `GITHUB_TOKEN` into the local `.git/config` after checkout. Any subsequent step — including the `Autobuild` step that runs project build logic, or a compromised transitive dependency — can read that token from disk and abuse it (e.g. push to the repo).

## Fix

The CodeQL workflow only needs to read source; it never uses git credentials after checkout (no push, no submodules). Setting `persist-credentials: false` prevents the token from being written to `.git/config`.

```yaml
- name: Checkout repository
  uses: actions/checkout@v3
  with:
    persist-credentials: false
```

This is the only workflow in the repo and the only `actions/checkout` usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)